### PR TITLE
Allow multiple filter patterns in the runsettings schema.

### DIFF
--- a/BoostTestAdapter/BoostTestAdapterSettings.xsd
+++ b/BoostTestAdapter/BoostTestAdapterSettings.xsd
@@ -87,7 +87,7 @@
 
   <xsd:complexType name="PatternList">
     <xsd:sequence>
-      <xsd:element name="Pattern" type="xsd:string" />
+      <xsd:element name="Pattern" minOccurs="0" maxOccurs="unbounded" type="xsd:string" />
     </xsd:sequence>
   </xsd:complexType>
 

--- a/BoostTestAdapterNunit/BoostTestSettingsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSettingsTest.cs
@@ -158,10 +158,10 @@ namespace BoostTestAdapterNunit
 
             Assert.That(settings.Filters, Is.Not.Null);
             Assert.That(settings.Filters.Include, Is.Not.Empty);
-            Assert.That(settings.Filters.Include, Is.EquivalentTo(new[] { "mytest.exe$" }));
+            Assert.That(settings.Filters.Include, Is.EquivalentTo(new[] { "mytest.exe$", "myothertest.exe$" }));
 
             Assert.That(settings.Filters.Exclude, Is.Not.Empty);
-            Assert.That(settings.Filters.Exclude, Is.EquivalentTo(new[] { "test.exe$" }));
+            Assert.That(settings.Filters.Exclude, Is.EquivalentTo(new[] { "test.exe$", "othertest.exe$" }));
         }
         
         /// <summary>

--- a/BoostTestAdapterNunit/Resources/Settings/sample.2.runsettings
+++ b/BoostTestAdapterNunit/Resources/Settings/sample.2.runsettings
@@ -47,17 +47,18 @@
         
         <!-- Test case-sensitivity -->
         <DetectFloatingPointExceptions>1</DetectFloatingPointExceptions>
-
 		
-		<RunDisabledTests>true</RunDisabledTests>
+		    <RunDisabledTests>true</RunDisabledTests>
 
         <Filters>
             <Exclude>
                 <Pattern>test.exe$</Pattern>
+                <Pattern>othertest.exe$</Pattern>
             </Exclude>
             <Include>
                 <Pattern>mytest.exe$</Pattern>
-            </Include>    
+                <Pattern>myothertest.exe$</Pattern>
+            </Include>
         </Filters>
     </BoostTest>
 </RunSettings>


### PR DESCRIPTION
This commit fixes issue #4.