### PR TITLE
dont log on initialization

### DIFF
--- a/BoostTestAdapter/Utility/Logger.cs
+++ b/BoostTestAdapter/Utility/Logger.cs
@@ -31,8 +31,6 @@ namespace BoostTestAdapter.Utility
             _loggerInstance = logger; //VS sink handle
 
             ConfigureLog4Net();
-
-            Info(Resources.LoggerInitialized, log4net.GlobalContext.Properties["LogFilePath"]);
         }
 
         /// <summary>


### PR DESCRIPTION
all adapters are always initialized (within reason) so this ends up showing up even when there's nothing to do with boost.test, leading to confusion and annoyance. We're logging everything else to the output window anyways so this isn't needed.