### PR TITLE
Avoid quoting command-line components if already within quotes

### DIFF
--- a/BoostTestAdapter/Utility/CommandLine.cs
+++ b/BoostTestAdapter/Utility/CommandLine.cs
@@ -65,6 +65,17 @@ namespace BoostTestAdapter.Utility
         }
 
         /// <summary>
+        /// Wraps the input string in the provided quotation marks if necessary
+        /// </summary>
+        /// <param name="input">The input string to enquote</param>
+        /// <param name="mark">The quotation mark to wrap the input in</param>
+        /// <returns>The input string quoted for command line use</returns>
+        internal static string Enquote(string input, char mark = '"')
+        {
+            return input.Contains(' ') ? string.Format(CultureInfo.InvariantCulture, "{0}{1}{0}", mark, input) : input;
+        }
+
+        /// <summary>
         /// Safely splits a command line string into its argument components.
         /// </summary>
         /// <param name="commandLine">The command line string to split</param>
@@ -77,13 +88,13 @@ namespace BoostTestAdapter.Utility
 
             return commandLine.Split(c =>
             {
-                if ((c == '\\') && (!isEscaping))
+                if ((c == '\\') && !isEscaping)
                 {
                     isEscaping = true;
                     return false;
                 }
 
-                if ((c == '\"') && (!isEscaping))
+                if ((c == '\"') && !isEscaping)
                 {
                     inQuotes = !inQuotes;
                 }
@@ -137,7 +148,7 @@ namespace BoostTestAdapter.Utility
 
         public override string ToString()
         {
-            return NormalizePath(FileName) + ' ' + Arguments;
+            return SanitizeArgument(FileName) + ' ' + Arguments;
         }
 
         /// <summary>
@@ -168,34 +179,34 @@ namespace BoostTestAdapter.Utility
                 return string.Empty;
             }
 
-            var quotedArgs = arguments.Select(arg => arg.Contains(' ') ? string.Format(CultureInfo.InvariantCulture, "\"{0}\"", arg) : arg);
+            var quotedArgs = arguments.Select(arg => CommandLineArgExtensions.Enquote(arg));
             return string.Join(" ", quotedArgs);
         }
 
         /// <summary>
-        /// Normalizes the file path and adds quotes should the path not be quoted already
+        /// Sanitizes the command line argument component for command line use
         /// </summary>
-        /// <param name="filePath">The path to notmalized</param>
-        /// <returns>A normalized file path</returns>
-        private static string NormalizePath(string filePath)
+        /// <param name="argument">The command line argument component to sanitize</param>
+        /// <returns>Sanitized command line argument</returns>
+        private static string SanitizeArgument(string argument)
         {
-            var path = filePath?.Trim();
+            var arg = argument?.Trim();
 
             // Invalid input, return immediately
-            if (string.IsNullOrEmpty(path))
+            if (string.IsNullOrEmpty(arg))
             {
-                return path;
+                return arg;
             }
 
             const char mark = '"';
 
             // If the path is already quoted, leave as is
-            if (CommandLineArgExtensions.IsQuoted(path, mark))
+            if (CommandLineArgExtensions.IsQuoted(arg, mark))
             {
-                return path;
+                return arg;
             }
 
-            return path.Contains(' ') ? (mark + path + mark) : path;
+            return CommandLineArgExtensions.Enquote(arg, mark);
         }
     }
 }

--- a/BoostTestAdapter/Utility/ExecutionContext/DefaultProcessExecutionContext.cs
+++ b/BoostTestAdapter/Utility/ExecutionContext/DefaultProcessExecutionContext.cs
@@ -8,13 +8,14 @@
 using JobManagement;
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 
 namespace BoostTestAdapter.Utility.ExecutionContext
 {
     /// <summary>
     /// An IProcessExecutionContext which produces regular sub-processes.
-    /// Guarantees that sub-processes are destoryed when this processes is killed.
+    /// Guarantees that sub-processes are destroyed when this processes is killed.
     /// </summary>
     public class DefaultProcessExecutionContext : IProcessExecutionContext
     {
@@ -106,7 +107,7 @@ namespace BoostTestAdapter.Utility.ExecutionContext
 
                 // Start the process through cmd.exe to allow redirection operators to work as expected
                 FileName = Path.Combine(Environment.SystemDirectory, "cmd.exe"),
-                Arguments = "/S /C \"\"" + args.FilePath + "\" " + args.Arguments + '"',
+                Arguments = string.Format(CultureInfo.InvariantCulture, "/S /C \"{0}\"", new CommandLine(args.FilePath, args.Arguments).ToString()),
 
                 // Redirection should be specified as part of 'args.Arguments' and sent to a file
                 RedirectStandardError = false,

--- a/BoostTestAdapterNunit/BoostTestSettingsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSettingsTest.cs
@@ -1,4 +1,4 @@
-﻿// (C) Copyright ETAS 2015.
+﻿// (C) Copyright 2015 ETAS GmbH (http://www.etas.com/)
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -108,7 +108,7 @@ namespace BoostTestAdapterNunit
 
             Assert.That(settings.ExternalTestRunner, Is.Not.Null);
             Assert.That(settings.ExternalTestRunner.ExtensionType.ToString(), Is.EqualTo(".dll"));
-            Assert.That(settings.ExternalTestRunner.ExecutionCommandLine.ToString(), Is.EqualTo("C:\\ExternalTestRunner.exe --test {source} "));
+            Assert.That(settings.ExternalTestRunner.ExecutionCommandLine.ToString(), Is.EqualTo("C:\\ExternalTestRunner.exe --test {source}"));
         }
 
         /// <summary>


### PR DESCRIPTION
Cherry-pick commit from ETAS fork which addresses issue #78