### PR TITLE
Execute Boost.Test processes in an `async` manner

### DIFF
--- a/BoostTestAdapter/Boost/Runner/IBoostTestRunner.cs
+++ b/BoostTestAdapter/Boost/Runner/IBoostTestRunner.cs
@@ -4,6 +4,8 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 using BoostTestAdapter.Utility.ExecutionContext;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace BoostTestAdapter.Boost.Runner
 {
@@ -18,10 +20,10 @@ namespace BoostTestAdapter.Boost.Runner
         /// <param name="args">The Boost Test framework command line options.</param>
         /// <param name="settings">The Boost Test runner settings.</param>
         /// <param name="executionContext">An IProcessExecutionContext which will manage any spawned process.</param>
+        /// <param name="token">A cancellation token to suspend test execution.</param>
         /// <returns>Boost.Test result code</returns>
-        /// <exception cref="TimeoutException">Thrown in case specified timeout threshold is exceeded.</exception>
-        int Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext executionContext);
-        
+        Task<int> ExecuteAsync(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext executionContext, CancellationToken token);
+
         /// <summary>
         /// Provides a source Id distinguishing different instances
         /// </summary>

--- a/BoostTestAdapter/Discoverers/ListContentDiscoverer.cs
+++ b/BoostTestAdapter/Discoverers/ListContentDiscoverer.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 
 namespace BoostTestAdapter.Discoverers
 {
@@ -110,7 +111,14 @@ namespace BoostTestAdapter.Discoverers
 
                         using (var context = new DefaultProcessExecutionContext())
                         {
-                            resultCode = runner.Execute(args, runnerSettings, context);
+                            var exec = runner.ExecuteAsync(args, runnerSettings, context, CancellationToken.None);
+
+                            if (!exec.Wait(runnerSettings.Timeout))
+                            {
+                                throw new Boost.Runner.TimeoutException(runnerSettings.Timeout);
+                            }
+
+                            resultCode = exec.Result;
                         }
 
                         // Skip sources for which the --list_content file is not available

--- a/BoostTestAdapter/Utility/TestRun.cs
+++ b/BoostTestAdapter/Utility/TestRun.cs
@@ -3,10 +3,12 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-using System.Collections.Generic;
 using BoostTestAdapter.Boost.Runner;
-using VSTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
 using BoostTestAdapter.Utility.ExecutionContext;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using VSTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
 
 namespace BoostTestAdapter.Utility
 {
@@ -48,9 +50,10 @@ namespace BoostTestAdapter.Utility
         /// Executes the contained IBoostTestRunner with the contained arguments and settings
         /// </summary>
         /// <param name="context">The execution context of spawned sub-processes</param>
-        public void Execute(IProcessExecutionContext context)
+        /// <param name="token">A cancellation token to suspend test execution.</param>
+        public Task<int> ExecuteAsync(IProcessExecutionContext context, CancellationToken token)
         {
-            this.Runner.Execute(this.Arguments, this.Settings, context);
+            return this.Runner.ExecuteAsync(this.Arguments, this.Settings, context, token);
         }
     }
 }

--- a/BoostTestAdapterNunit/BoostTestDiscovererTest.cs
+++ b/BoostTestAdapterNunit/BoostTestDiscovererTest.cs
@@ -18,6 +18,8 @@ using NUnit.Framework;
 using BoostTestAdapter.Boost.Runner;
 using FakeItEasy;
 using BoostTestAdapter.Utility.ExecutionContext;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace BoostTestAdapterNunit
 {
@@ -194,10 +196,10 @@ namespace BoostTestAdapterNunit
 
         public string Source { get; private set; }
 
-        public int Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext context)
+        public Task<int> ExecuteAsync(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext context, CancellationToken token)
         {
             Copy("BoostTestAdapterNunit.Resources.ListContentDOT.sample.8.list.content.gv", args.StandardErrorFile);
-            return 0;
+            return Task.FromResult(0);
         }
 
         private void Copy(string embeddedResource, string path)

--- a/BoostTestAdapterNunit/DOTDeserialisationTest.cs
+++ b/BoostTestAdapterNunit/DOTDeserialisationTest.cs
@@ -56,8 +56,7 @@ namespace BoostTestAdapterNunit
         /// <param name="encoding">The encoding by which to interpret the resource file</param>
         private void Compare(string resource, TestFramework expected, Encoding encoding)
         {
-            using (var stream = TestHelper.LoadEmbeddedResource(resource))
-            using (var reader = new StreamReader(stream, encoding))
+            using (var reader = new StreamReader(TestHelper.LoadEmbeddedResource(resource), encoding))
             {
                 TestFrameworkDOTDeserialiser parser = new TestFrameworkDOTDeserialiser(Source);
                 TestFramework framework = parser.Deserialise(reader);

--- a/BoostTestAdapterNunit/ListContentDiscovererTest.cs
+++ b/BoostTestAdapterNunit/ListContentDiscovererTest.cs
@@ -23,6 +23,8 @@ using NUnit.Framework;
 
 using VSTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
 using BoostTestAdapter.Utility.ExecutionContext;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace BoostTestAdapterNunit
 {
@@ -80,14 +82,14 @@ namespace BoostTestAdapterNunit
             string output = null;
 
             A.CallTo(() => runner.ListContentSupported).Returns(true);
-            A.CallTo(() => runner.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).Invokes((call) =>
+            A.CallTo(() => runner.ExecuteAsync(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._, A<CancellationToken>._)).Invokes((call) =>
             {
                 BoostTestRunnerCommandLineArgs args = (BoostTestRunnerCommandLineArgs) call.Arguments.First();
                 if ((args.ListContent.HasValue) && (args.ListContent.Value == ListContentFormat.DOT))
                 {
                     output = TestHelper.CopyEmbeddedResourceToDirectory("BoostTestAdapterNunit.Resources.ListContentDOT.sample.8.list.content.gv", args.StandardErrorFile);
                 }             
-            }).Returns(0);
+            }).Returns(Task.FromResult(0));
 
             FakeBoostTestRunnerFactory factory = new FakeBoostTestRunnerFactory(runner);
             ListContentDiscoverer discoverer = new ListContentDiscoverer(factory, DummyBoostTestPackageServiceFactory.Default);
@@ -101,7 +103,7 @@ namespace BoostTestAdapterNunit
             Assert.That(factory.ProvisionedRunners.Count, Is.EqualTo(1));
             foreach (IBoostTestRunner provisioned in factory.ProvisionedRunners.Select(provision => provision.Item3))
             {
-                A.CallTo(() => provisioned.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).
+                A.CallTo(() => provisioned.ExecuteAsync(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._, A<CancellationToken>._)).
                     WhenArgumentsMatch((arguments) =>
                     {
                         BoostTestRunnerCommandLineArgs args = (BoostTestRunnerCommandLineArgs) arguments.First();
@@ -138,7 +140,7 @@ namespace BoostTestAdapterNunit
             IBoostTestRunner runner = A.Fake<IBoostTestRunner>();
                         
             A.CallTo(() => runner.ListContentSupported).Returns(true);
-            A.CallTo(() => runner.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).Returns(-1073741515);
+            A.CallTo(() => runner.ExecuteAsync(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._, A<CancellationToken>._)).Returns(Task.FromResult(-1073741515));
 
             FakeBoostTestRunnerFactory factory = new FakeBoostTestRunnerFactory(runner);
             ListContentDiscoverer discoverer = new ListContentDiscoverer(factory, DummyBoostTestPackageServiceFactory.Default);


### PR DESCRIPTION
Following the discussion in PR #93, this change is an attempt to get in line with @LukaszMendakiewicz requests and utilise `EnableRaisingEvents`.