### PR TITLE
Add One-Shot test batch strategy

### DIFF
--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
@@ -248,6 +248,8 @@ namespace BoostTestAdapter.Boost.Runner
         /// <summary>
         /// List of fully qualified name tests which are to be executed.
         /// </summary>
+        /// <remarks>The semantics of this property follow the documentation of Boost.Test's --run_test argument for Boost 1.61</remarks>
+        /// <remarks>This property cannot handle multiple filter definitions as described in documentation of Boost.Test's --run_test argument for Boost 1.63</remarks>
         public IList<string> Tests { get; private set; }
 
         /// <summary>

--- a/BoostTestAdapter/BoostTestAdapter.csproj
+++ b/BoostTestAdapter/BoostTestAdapter.csproj
@@ -145,6 +145,7 @@
     <Compile Include="TestBatch\SourceTestBatchStrategy.cs" />
     <Compile Include="TestBatch\TestBatchStrategy.cs" />
     <Compile Include="TestBatch\TestSuiteTestBatchStrategy.cs" />
+    <Compile Include="TestBatch\OneShotTestBatchStrategy.cs" />
     <Compile Include="Utility\Code.cs" />
     <Compile Include="Utility\CommandEvaluator.cs" />
     <Compile Include="Utility\CommandLine.cs" />

--- a/BoostTestAdapter/BoostTestAdapterSettings.xsd
+++ b/BoostTestAdapter/BoostTestAdapterSettings.xsd
@@ -61,6 +61,7 @@
       <xsd:enumeration value="Source" />
       <xsd:enumeration value="TestSuite" />
       <xsd:enumeration value="TestCase" />
+      <xsd:enumeration value="One" />
     </xsd:restriction>
   </xsd:simpleType>
 

--- a/BoostTestAdapter/BoostTestExecutor.cs
+++ b/BoostTestAdapter/BoostTestExecutor.cs
@@ -217,7 +217,7 @@ namespace BoostTestAdapter
                         // Batch tests into grouped runs based by source so that we avoid reloading symbols per test run
                         // Batching by source since this overload is called when 'Run All...' or equivalent is triggered
                         // NOTE For code-coverage speed is given preference over adapter responsiveness.
-                        TestBatch.Strategy strategy = ((runContext.IsDataCollectionEnabled) ? TestBatch.Strategy.Source : settings.TestBatchStrategy);
+                        Strategy strategy = ((runContext.IsDataCollectionEnabled) ? Strategy.Source : settings.TestBatchStrategy);
 
                         ITestBatchingStrategy batchStrategy = GetBatchStrategy(strategy, settings);
                         if (batchStrategy == null)
@@ -267,7 +267,7 @@ namespace BoostTestAdapter
             //      multiple test name specification for tests which reside in the same test suite
             //
             // NOTE For code-coverage speed is given preference over adapter responsiveness.
-            TestBatch.Strategy strategy = ((runContext.IsDataCollectionEnabled) ? TestBatch.Strategy.TestSuite : settings.TestBatchStrategy);
+            TestBatch.Strategy strategy = ((runContext.IsDataCollectionEnabled) ? Strategy.One : settings.TestBatchStrategy);
             // Source strategy is invalid in such context since explicit tests are chosen. TestSuite is used instead.
             if (strategy == Strategy.Source)
             {
@@ -317,9 +317,10 @@ namespace BoostTestAdapter
 
             switch (strategy)
             {
-                case Strategy.Source: return new SourceTestBatchStrategy(this._testRunnerFactory, settings, argsBuilder);
-                case Strategy.TestSuite: return new TestSuiteTestBatchStrategy(this._testRunnerFactory, settings, argsBuilder);
-                case Strategy.TestCase: return new IndividualTestBatchStrategy(this._testRunnerFactory, settings, argsBuilder);
+                case Strategy.Source: return new SourceTestBatchStrategy(_testRunnerFactory, settings, argsBuilder);
+                case Strategy.TestSuite: return new TestSuiteTestBatchStrategy(_testRunnerFactory, settings, argsBuilder);
+                case Strategy.TestCase: return new IndividualTestBatchStrategy(_testRunnerFactory, settings, argsBuilder);
+                case Strategy.One: return new OneShotTestBatchStrategy(_testRunnerFactory, settings, argsBuilder);
             }
 
             return null;
@@ -467,7 +468,7 @@ namespace BoostTestAdapter
             
             args.StandardOutFile = ((settings.EnableStdOutRedirection) ? TestPathGenerator.Generate(source, FileExtensions.StdOutFile) : null);
             args.StandardErrorFile = ((settings.EnableStdErrRedirection) ? TestPathGenerator.Generate(source, FileExtensions.StdErrFile) : null);
-
+            
             return args;
         }
         

--- a/BoostTestAdapter/TestBatch/OneShotTestBatchStrategy.cs
+++ b/BoostTestAdapter/TestBatch/OneShotTestBatchStrategy.cs
@@ -1,0 +1,250 @@
+﻿// (C) Copyright ETAS 2015.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using BoostTestAdapter.Utility;
+using BoostTestAdapter.Settings;
+using BoostTestAdapter.Boost.Runner;
+using BoostTestAdapter.Utility.VisualStudio;
+
+using VSTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
+
+namespace BoostTestAdapter.TestBatch
+{
+    public class OneShotTestBatchStrategy : TestBatchStrategy
+    {
+        #region Constants
+
+        private static readonly Version _minimumVersion = new Version(1, 63, 0);
+        private static readonly Version _zero = new Version(0, 0, 0);
+
+        #endregion
+
+        #region Constructors
+
+        public OneShotTestBatchStrategy(IBoostTestRunnerFactory testRunnerFactory, BoostTestAdapterSettings settings, CommandLineArgsBuilder argsBuilder)
+            : base(testRunnerFactory, settings, argsBuilder)
+        {
+            _fallBackStrategy = new TestSuiteTestBatchStrategy(testRunnerFactory, settings, argsBuilder);
+        }
+
+        #endregion
+
+        #region Members
+
+        private readonly TestSuiteTestBatchStrategy _fallBackStrategy;
+
+        #endregion
+
+        #region TestBatchStrategy
+
+        public override IEnumerable<TestRun> BatchTests(IEnumerable<VSTestCase> tests)
+        {
+            BoostTestRunnerSettings adaptedSettings = this.Settings.TestRunnerSettings.Clone();
+            // Disable timeout since this batching strategy executes more than one test at a time
+            adaptedSettings.Timeout = -1;
+
+            // Group by source
+            IEnumerable<IGrouping<string, VSTestCase>> sources = tests.GroupBy(test => test.Source);
+            foreach (var source in sources)
+            {
+                IBoostTestRunner runner = GetTestRunner(source.Key);
+                if (runner == null)
+                {
+                    continue;
+                }
+
+                // Start by batching tests by TestSuite
+                var batch = _fallBackStrategy.BatchTests(source);
+                
+                // If the Boost.Test module supports test run filters...
+                if (source.Select(GetVersion).All(version => (version >= _minimumVersion)))
+                {
+                    BoostTestRunnerCommandLineArgs args = BuildCommandLineArgs(source.Key);
+
+                    // Generate the filter set
+                    var filterSet = new List<TestFilter>();
+
+                    foreach (var run in batch)
+                    {
+                        TestFilter filter = TestFilter.EnableFilter();
+
+                        // Use the command-line representation of the test suite batch to allow
+                        // for the most compact representation (i.e. fully/qualified/test_name_0,test_name_1,test_name_2)
+                        filter.TestSet = new PathTestSet(run.Arguments.Tests);
+                        
+                        filterSet.Add(filter);
+                    }
+
+                    // Use the environment variable rather than the command-line '--run_test' to make proper use of test run filters
+                    args.Environment["BOOST_TEST_RUN_FILTERS"] = string.Join(":", filterSet);
+                    
+                    yield return new TestRun(runner, source, args, adaptedSettings);
+                }
+                // Else fall-back to regular test suite batching behaviour...
+                else
+                {
+                    foreach (var run in batch)
+                    {
+                        yield return run;
+                    }
+                }                
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Extracts the Boost version from the provided test case
+        /// </summary>
+        /// <param name="test">The test case to extract the version from</param>
+        /// <returns>The version advertised by the provided test case or the zero version if the version is not available</returns>
+        private static Version GetVersion(VSTestCase test)
+        {
+            // Use the Zero version as a dummy to identify a missing Boost Version property
+            Version result = _zero;
+
+            if (test != null)
+            {
+                string value = (string)test.GetPropertyValue(VSTestModel.VersionProperty);
+
+                if (string.IsNullOrEmpty(value) || !Version.TryParse(value, out result))
+                {
+                    result = _zero;
+                }
+            }
+
+            return result;
+        }
+
+        #region Boost Test Filtering
+
+        /// <summary>
+        /// Boost.Test test filter representation
+        /// </summary>
+        private class TestFilter
+        {
+            /// <summary>
+            /// Internal Constructor
+            /// </summary>
+            /// <param name="relativeSpec">Identifies if this is an 'enable' filter or otherwise</param>
+            private TestFilter(bool relativeSpec)
+            {
+                this.RelativeSpec = relativeSpec;
+            }
+
+            /// <summary>
+            /// States if this is an 'enable' filter or otherwise
+            /// </summary>
+            public bool RelativeSpec { get; private set; }
+
+            /// <summary>
+            /// The test set
+            /// </summary>
+            public ITestSet TestSet { get; set; }
+
+            /// <summary>
+            /// Named constructor which creates an 'enabled' test filter. The test set
+            /// represented will be executed.
+            /// </summary>
+            /// <returns>A new TestFilter instance whose TestSet will be enabled for execution</returns>
+            public static TestFilter EnableFilter()
+            {
+                return new TestFilter(true);
+            }
+
+            /// <summary>
+            /// Named constructor which creates a 'disabled' test filter. The test set
+            /// represented will not be executed.
+            /// </summary>
+            /// <returns>A new TestFilter instance whose TestSet will not be enabled for execution</returns>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+            public static TestFilter DisableFilter()
+            {
+                return new TestFilter(false);
+            }
+            public override string ToString()
+            {
+                return (RelativeSpec ? '+' : '!') + this.TestSet.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Identifies a 'test_set' as specified in Boost.Test <see cref="http://www.boost.org/doc/libs/1_63_0/libs/test/doc/html/boost_test/utf_reference/rt_param_reference/run_test.html">--run_test</see> documentation
+        /// </summary>
+        private interface ITestSet
+        {
+        }
+
+        /// <summary>
+        /// A 'label' test set which represents
+        /// all tests identified with said label
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses")]
+        private class LabelTestSet : ITestSet
+        {
+            /// <summary>
+            /// Constructor
+            /// </summary>
+            /// <param name="label">The test label</param>
+            public LabelTestSet(string label)
+            {
+                this.Label = label;
+            }
+
+            /// <summary>
+            /// Test label (decorator) value
+            /// </summary>
+            public string Label { get; private set; }
+
+            public override string ToString()
+            {
+                return '@' + this.Label;
+            }
+        }
+
+        /// <summary>
+        /// A 'path' test set which represents a collection
+        /// of Boost.Test paths
+        /// </summary>
+        /// <remarks>The first path is expected to be fully-qualified</remarks>
+        /// <remarks>Paths following the first path are relative to the parent test suite of the first fully-qualified test</remarks>
+        private class PathTestSet : ITestSet
+        {
+            /// <summary>
+            /// Default Constructor
+            /// </summary>
+            public PathTestSet()
+                : this(new List<string>())
+            {
+            }
+
+            /// <summary>
+            /// Constructor
+            /// </summary>
+            /// <param name="paths">The base list which is to be used</param>
+            /// <remarks>The list is shallow copied. Any modifications Paths through this instance will also affect the provided list.</remarks>
+            public PathTestSet(IList<string> paths)
+            {
+                this.Paths = paths;
+            }
+
+            /// <summary>
+            /// Test paths
+            /// </summary>
+            public IList<string> Paths { get; private set; }
+
+            public override string ToString()
+            {
+                return string.Join(",", this.Paths);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/BoostTestAdapter/TestBatch/TestBatchStrategy.cs
+++ b/BoostTestAdapter/TestBatch/TestBatchStrategy.cs
@@ -19,7 +19,8 @@ namespace BoostTestAdapter.TestBatch
     {
         Source,
         TestSuite,
-        TestCase
+        TestCase,
+        One
     }
 
     /// <summary>

--- a/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
+++ b/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
@@ -48,12 +48,25 @@ namespace BoostTestAdapter.Utility.VisualStudio
             }
         }
 
+        private static readonly TestProperty _version = TestProperty.Register("Boost.Test.Boost.Version", "Boost Version", typeof(string), typeof(VSTestModel));
+
+        /// <summary>
+        /// Boost.Test Boost Version property
+        /// </summary>
+        public static TestProperty VersionProperty
+        {
+            get
+            {
+                return _version;
+            }
+        }
+
         /// <summary>
         /// Converts forward slashes in a file path to backward slashes.
         /// </summary>
         /// <param name="path_in"> The input path</param>
         /// <returns>The output path, modified with backward slashes </returns>
-       
+
         private static string ConvertSlashes(string path_in)
         {
             return path_in.Replace('/', '\\');

--- a/BoostTestAdapterNunit/BatchStrategyTest.cs
+++ b/BoostTestAdapterNunit/BatchStrategyTest.cs
@@ -1,0 +1,154 @@
+﻿// (C) Copyright ETAS 2015.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+using System.Linq;
+using System.Collections.Generic;
+
+using FakeItEasy;
+
+using NUnit.Framework;
+
+using BoostTestAdapter.Boost.Runner;
+using BoostTestAdapter.TestBatch;
+using BoostTestAdapter.Settings;
+
+using VSTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
+using BoostTestAdapter;
+using BoostTestAdapter.Utility.VisualStudio;
+
+namespace BoostTestAdapterNunit
+{
+    [TestFixture]
+    class BatchStrategyTest
+    {
+        #region Test Setup/Teardown
+
+        /// <summary>
+        /// Test Setup
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            RunnerFactory = A.Fake<IBoostTestRunnerFactory>();
+            A.CallTo(() => RunnerFactory.GetRunner(A<string>._, A<BoostTestRunnerFactoryOptions>._)).Returns(A.Fake<IBoostTestRunner>());
+
+            Settings = new BoostTestAdapterSettings();
+
+            ArgsBuilder = (string source, BoostTestAdapterSettings settings) => { return new BoostTestRunnerCommandLineArgs(); };
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Dummy/Default Test Runner Provider
+        /// </summary>
+        private IBoostTestRunnerFactory RunnerFactory { get; set; }
+
+        /// <summary>
+        /// Dummy/Default Test Adapter Settings
+        /// </summary>
+        private BoostTestAdapterSettings Settings { get; set; }
+
+        /// <summary>
+        /// Dummy/Default Boost.Test Command Line Arguments Builder
+        /// </summary>
+        private CommandLineArgsBuilder ArgsBuilder { get; set; }
+
+        #endregion
+
+        #region Helper Methods
+
+        /// <summary>
+        /// Given a VSTestCase as a template, generates up to count test instances
+        /// based on the provided template with a unique name for each
+        /// </summary>
+        /// <param name="template">The template test case instance to base the generated instances upon</param>
+        /// <param name="count">The total number of dummy test cases to generate</param>
+        /// <returns>A collection of dummy test cases based on the provided template</returns>
+        private IEnumerable<VSTestCase> GenerateDummyTests(VSTestCase template, int count)
+        {
+            for (int i = 0; i < count; ++i)
+            {
+                var test = new VSTestCase(template.FullyQualifiedName, template.ExecutorUri, template.Source);
+                
+                foreach (var property in template.Properties)
+                {
+                    test.SetPropertyValue(property, template.GetPropertyValue(property));
+                }
+
+                // Add a suffix to allow tests to be distinguishable
+                test.FullyQualifiedName += '_' + i.ToString();
+
+                yield return test;
+            }
+        }
+
+        #endregion
+
+        #region Tests
+
+        /// <summary>
+        /// Assert that: Given a series of tests from a Boost 1.63 module/source, the One-Shot test
+        ///              strategy batches all tests in 1 test run
+        /// </summary>
+        [Test]
+        public void OneShotBatchTestStrategy()
+        {
+            var strategy = new OneShotTestBatchStrategy(RunnerFactory, Settings, ArgsBuilder);
+
+            var template = new VSTestCase("test", BoostTestExecutor.ExecutorUri, "source");
+            template.SetPropertyValue(VSTestModel.VersionProperty, "1.63.0");
+            template.Traits.Add(VSTestModel.TestSuiteTrait, "Master Test Suite");
+
+            var tests = GenerateDummyTests(template, 10).ToList();
+            var batch = strategy.BatchTests(tests).ToList();
+
+            Assert.That(batch.Count, Is.EqualTo(1));
+
+            var run = batch.First();
+
+            Assert.That(run.Tests, Is.EqualTo(tests));
+            // --run_test should be avoided due to backwards compatibility
+            Assert.That(run.Arguments.Tests, Is.Empty);
+            // instead, the respective environment variable BOOST_TEST_RUN_FILTERS is to be used
+            Assert.That(run.Arguments.Environment.ContainsKey("BOOST_TEST_RUN_FILTERS"), Is.True);
+        }
+
+        /// <summary>
+        /// Assert that: Given a series of tests from a Boost 1.60 module/source, the One-Shot test
+        ///              strategy batches all tests as if the TestSuite batch strategy is used
+        /// </summary>
+        [Test]
+        public void OneShotBatchTestStrategyForOldBoost()
+        {
+            var strategy = new OneShotTestBatchStrategy(RunnerFactory, Settings, ArgsBuilder);
+
+            var template = new VSTestCase("test", BoostTestExecutor.ExecutorUri, "source");
+            template.SetPropertyValue(VSTestModel.VersionProperty, null);
+            template.Traits.Add(VSTestModel.TestSuiteTrait, "Master Test Suite");
+
+            var template2 = new VSTestCase("test", BoostTestExecutor.ExecutorUri, "source");
+            template2.SetPropertyValue(VSTestModel.VersionProperty, null);
+            template2.Traits.Add(VSTestModel.TestSuiteTrait, "suite");
+
+            var tests = GenerateDummyTests(template, 2).Concat(GenerateDummyTests(template2, 2)).ToList();
+            var batch = strategy.BatchTests(tests).ToList();
+            
+            // 2 test runs, 1 for "Master Test Suite" and 1 for "suite"
+            Assert.That(batch.Count, Is.EqualTo(2));
+            
+            foreach (var run in batch)
+            {
+                // The --run_test argument is to be used instead of the "BOOST_TEST_RUN_FILTERS" environment variable
+                Assert.That(run.Arguments.Tests, Is.Not.Empty);
+                Assert.That(run.Arguments.Environment.ContainsKey("BOOST_TEST_RUN_FILTERS"), Is.False);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
+++ b/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
@@ -34,6 +34,7 @@
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup Condition="'$(RealSign)' != 'True'">
+    <Compile Include="BatchStrategyTest.cs" />
     <Compile Include="BoostDataTestCaseVerifierTest.cs" />
     <Compile Include="BoostTestDiscovererFactoryTest.cs" />
     <Compile Include="BoostTestDiscovererTest.cs" />

--- a/BoostTestAdapterNunit/BoostTestSettingsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSettingsTest.cs
@@ -195,6 +195,38 @@ namespace BoostTestAdapterNunit
             return settings.PostTestDelay;
         }
 
+        /// <summary>
+        /// The 'CatchSystemErrors' option can be properly parsed
+        /// 
+        /// Test aims:
+        ///     - Assert that: the 'CatchSystemErrors' option can be properly parsed
+        /// </summary>
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><CatchSystemErrors>true</CatchSystemErrors></BoostTest></RunSettings>", Result = true)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><CatchSystemErrors>1</CatchSystemErrors></BoostTest></RunSettings>", Result = true)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><CatchSystemErrors>false</CatchSystemErrors></BoostTest></RunSettings>", Result = false)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><CatchSystemErrors>0</CatchSystemErrors></BoostTest></RunSettings>", Result = false)]
+        public bool? ParseCatchSystemErrorsOption(string settingsXml)
+        {
+            BoostTestAdapterSettings settings = ParseXml(settingsXml);
+            return settings.CatchSystemErrors;
+        }
+        
+        /// <summary>
+        /// The 'TestBatchStrategy' option can be properly parsed
+        /// 
+        /// Test aims:
+        ///     - Assert that: The 'TestBatchStrategy' option can be properly parsed 
+        /// </summary>
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><TestBatchStrategy>TestCase</TestBatchStrategy></BoostTest></RunSettings>", Result = Strategy.TestCase)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><TestBatchStrategy>TestSuite</TestBatchStrategy></BoostTest></RunSettings>", Result = Strategy.TestSuite)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><TestBatchStrategy>Source</TestBatchStrategy></BoostTest></RunSettings>", Result = Strategy.Source)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><TestBatchStrategy>One</TestBatchStrategy></BoostTest></RunSettings>", Result = Strategy.One)]
+        public Strategy ParseTestBatchStrategy(string settingsXml)
+        {
+            BoostTestAdapterSettings settings = ParseXml(settingsXml);
+            return settings.TestBatchStrategy;
+        }
+
         #endregion Tests
     }
 }


### PR DESCRIPTION
Adds a new test-batch strategy which takes advantage of Boost.Test's new command-line `--run_test` format delivered in Boost 1.63. This allows for less invocations of the test module by aggregating tests across multiple test suites into one invocation.

Note that although this feature is enabled, it is currently not used/active since the discoverer needs to properly communicate version information through test properties. This will be (hopefully) delivered in the near future.