### PR TITLE
Add Boost Test Adapter 'red-pill'

### DIFF
--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
@@ -230,7 +230,17 @@ namespace BoostTestAdapter.Boost.Runner
             this.ListContent = null;
             this.Help = false;
 
-            this.Environment = new Dictionary<string, string>();
+            /* The environment variable "BUTA" is set whenever a test is executed. The purpose
+             * is to provide a means for boost unit tests to detect that they are being executed
+             * using the boost unit test adapter. One might use this so as for the tests to 
+             * increase the verbosity level whenever boost unit tests are executed using the
+             * boost unit test adapter.
+             */
+
+            this.Environment = new Dictionary<string, string>()
+            {
+                { "BUTA", "1" }
+            };
         }
 
         #endregion Constructors

--- a/BoostTestAdapterNunit/BoostTestExecutorTest.cs
+++ b/BoostTestAdapterNunit/BoostTestExecutorTest.cs
@@ -579,6 +579,7 @@ namespace BoostTestAdapterNunit
             );
 
             AssertDefaultTestResultProperties(this.FrameworkHandle.Results);
+
         }
 
         /// <summary>
@@ -604,6 +605,37 @@ namespace BoostTestAdapterNunit
             Assert.That(runner.ExecutionArgs.First().Context, Is.TypeOf<DebugFrameworkExecutionContext>());
 
             AssertDefaultTestResultProperties(this.FrameworkHandle.Results);
+        }
+
+        /// <summary>
+        /// "BUTA" environment variable should be set within an execution context.
+        /// 
+        /// Test aims:
+        ///     - Ensure that the text execution runner provides the environment variable "BUTA" in the execution
+        ///     context
+        /// </summary>
+        [Test]
+        public void BUTAEnvironmentVariableProvided()
+        {
+            this.RunContext.IsBeingDebugged = true;
+
+            this.Executor.RunTests(
+                GetDefaultTests(),
+                this.RunContext,
+                this.FrameworkHandle
+            );
+
+            MockBoostTestRunner runner = this.RunnerFactory.LastTestRunner as MockBoostTestRunner;
+
+            Assert.That(runner, Is.Not.Null);
+
+            var oExpectedEnvironmentVariables = new Dictionary<string, string>()
+            {
+                { "BUTA", "1" }
+            };
+
+            CollectionAssert.AreEqual(oExpectedEnvironmentVariables, runner.ExecutionArgs.First().Arguments.Environment);
+
         }
 
         /// <summary>

--- a/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
@@ -5,6 +5,7 @@
 
 using BoostTestAdapter.Boost.Runner;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO;
 
 namespace BoostTestAdapterNunit
@@ -69,6 +70,25 @@ namespace BoostTestAdapterNunit
         {
             BoostTestRunnerCommandLineArgs args = new BoostTestRunnerCommandLineArgs();
             Assert.That(args.ToString(), Is.Empty);
+        }
+
+        /// <summary>
+        /// "BUTA" environment variable present by default in the environment variable collection
+        /// 
+        /// Test aims:
+        ///     - Ensure that the "BUTA" environment is present by default in the enviorment variable collection.
+        /// </summary>
+        [Test]
+        public void BUTAEnviormentVariablePresent()
+        {
+            BoostTestRunnerCommandLineArgs args = new BoostTestRunnerCommandLineArgs();
+
+            var oExpectedEnviormentVariables = new Dictionary<string, string>()
+            {
+                { "BUTA", "1" }
+            };
+
+            CollectionAssert.AreEqual(oExpectedEnviormentVariables, args.Environment);
         }
 
         /// <summary>
@@ -144,6 +164,7 @@ namespace BoostTestAdapterNunit
             Assert.That(args.ListContent, Is.EqualTo(clone.ListContent));
 
             Assert.That(args.ToString(), Is.EqualTo(clone.ToString()));
+            Assert.That(args.Environment, Is.EqualTo(clone.Environment));
         }
 
         /// <summary>


### PR DESCRIPTION
Cherry pick of  etas/vs-boost-unit-test-adapter@39cd476.

Test executions through the Boost.Test adapter can be noted at runtime by testing for the environment variable `BUTA`. This allows test modules to adapt their behaviour depending on the runtime environment (e.g. disable tests, emit additional output etc.).