### PR TITLE
Specify VSTestCase.FullyQualifiedName as dot-separated Boost.Test path name

### DIFF
--- a/BoostTestAdapter/Boost/Test/TestUnit.cs
+++ b/BoostTestAdapter/Boost/Test/TestUnit.cs
@@ -120,6 +120,17 @@ namespace BoostTestAdapter.Boost.Test
         #endregion Properties
 
         /// <summary>
+        /// Identifies the fully qualified name of this TestUnit
+        /// </summary>
+        /// <param name="separator">Path component separator</param>
+        /// <returns>Fully qualified name of this TestUnit</returns>
+        /// <seealso cref="FullyQualifiedName"/>
+        public string GetFullyQualifiedName(string separator)
+        {
+            return FullyQualifiedNameBuilder.ToString(separator);
+        }
+
+        /// <summary>
         /// Adds a child to this TestUnit
         /// </summary>
         /// <param name="unit">The unit to add as a child</param>

--- a/BoostTestAdapter/BoostTestExecutor.cs
+++ b/BoostTestAdapter/BoostTestExecutor.cs
@@ -538,7 +538,7 @@ namespace BoostTestAdapter
                     return testRun.Tests.Select(test => {
                         var exception = new BoostTestResult();
                         
-                        exception.Unit = Boost.Test.TestUnit.FromFullyQualifiedName(test.FullyQualifiedName);
+                        exception.Unit = Boost.Test.TestUnit.FromFullyQualifiedName(test.GetBoostTestPath());
 
                         // NOTE Divide by 10 to compensate for duration calculation described in VSTestResult.AsVSTestResult(this Boost.Results.TestResult, VSTestCase)
                         exception.Duration = ((ulong)(end - start).Ticks) / 10;
@@ -559,7 +559,7 @@ namespace BoostTestAdapter
                 {
                     // Locate the test result associated to the current test
                     BoostTestResult result = null;
-                    return (results.TryGetValue(test.FullyQualifiedName, out result)) ? GenerateResult(test, result, start, end) : null;
+                    return (results.TryGetValue(test.GetBoostTestPath(), out result)) ? GenerateResult(test, result, start, end) : null;
                 }).
                 Where(result => (result != null));
         }
@@ -633,11 +633,11 @@ namespace BoostTestAdapter
         /// <returns>A suitable 'not-found' for the provided test case.</returns>
         private static string GetNotFoundErrorMessage(VSTestCase test)
         {
-            if (test.FullyQualifiedName.Contains(' '))
+            if (test.GetBoostTestPath().Contains(' '))
             {
                 return Resources.TestNameContainsSpaces;
             }
-            else if (test.FullyQualifiedName.Contains(','))
+            else if (test.GetBoostTestPath().Contains(','))
             {
                 return Resources.TestNameContainsCommas;
             }

--- a/BoostTestAdapter/Discoverers/VSDiscoveryVisitor.cs
+++ b/BoostTestAdapter/Discoverers/VSDiscoveryVisitor.cs
@@ -117,7 +117,9 @@ namespace BoostTestAdapter.Discoverers
         private VSTestCase GenerateTestCase(TestCase testCase)
         {
             VSTestCase test = new VSTestCase(
-                testCase.FullyQualifiedName,
+                // Use a dot-separated scheme to adhere to Visual Studio's protocol
+                // to automatically allow for test suite hierarchical representation
+                testCase.GetFullyQualifiedName("."),
                 BoostTestExecutor.ExecutorUri,
                 this.Source
             );
@@ -156,6 +158,9 @@ namespace BoostTestAdapter.Discoverers
                 // Reference: http://www.boost.org/doc/libs/1_60_0/libs/test/doc/html/boost_test/tests_organization/tests_grouping.html
                 unit = unit.Parent;
             }
+
+            // Record (unmodified) test path as expected by Boost.Test
+            test.SetBoostTestPath(testCase.FullyQualifiedName);
 
             return test;
         }

--- a/BoostTestAdapter/TestBatch/IndividualTestBatchStrategy.cs
+++ b/BoostTestAdapter/TestBatch/IndividualTestBatchStrategy.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using BoostTestAdapter.Boost.Runner;
 using BoostTestAdapter.Settings;
 using BoostTestAdapter.Utility;
-
+using BoostTestAdapter.Utility.VisualStudio;
 using VSTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
 
 namespace BoostTestAdapter.TestBatch
@@ -41,7 +41,7 @@ namespace BoostTestAdapter.TestBatch
                 foreach (VSTestCase test in source)
                 {
                     BoostTestRunnerCommandLineArgs args = BuildCommandLineArgs(runner.Source);
-                    args.Tests.Add(test.FullyQualifiedName);
+                    args.Tests.Add(test.GetBoostTestPath());
 
                     yield return new TestRun(runner, new VSTestCase[] { test }, args, this.Settings.TestRunnerSettings);
                 }

--- a/BoostTestAdapter/TestBatch/TestBatchStrategy.cs
+++ b/BoostTestAdapter/TestBatch/TestBatchStrategy.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using BoostTestAdapter.Boost.Runner;
 using BoostTestAdapter.Settings;
 using BoostTestAdapter.Utility;
-
 using VSTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
 
 namespace BoostTestAdapter.TestBatch

--- a/BoostTestAdapter/TestBatch/TestSuiteTestBatchStrategy.cs
+++ b/BoostTestAdapter/TestBatch/TestSuiteTestBatchStrategy.cs
@@ -49,8 +49,10 @@ namespace BoostTestAdapter.TestBatch
                     BoostTestRunnerCommandLineArgs args = BuildCommandLineArgs(source.Key);
                     foreach (VSTestCase test in suiteGroup)
                     {
+                        var path = test.GetBoostTestPath();
+
                         // List all tests by name but ensure that the first test is fully qualified so that remaining tests are taken relative to this test suite
-                        args.Tests.Add((args.Tests.Count == 0) ? test.FullyQualifiedName : QualifiedNameBuilder.FromString(test.FullyQualifiedName).Peek());
+                        args.Tests.Add((args.Tests.Count == 0) ? path : QualifiedNameBuilder.FromString(path).Peek());
                     }
 
                     yield return new TestRun(runner, suiteGroup, args, adaptedSettings);

--- a/BoostTestAdapter/Utility/QualifiedNameBuilder.cs
+++ b/BoostTestAdapter/Utility/QualifiedNameBuilder.cs
@@ -160,7 +160,18 @@ namespace BoostTestAdapter.Utility
         public override string ToString()
         {
             // Skip the Master Test Suite. Master Test Suite is omitted in qualified name.
-            return string.Join(Separator, this.Path.Skip(1));
+            return ToString(Separator);
+        }
+
+        /// <summary>
+        /// Provides a string representation of this fully qualified name as expected by Boost Test standards.
+        /// </summary>
+        /// <param name="separator">Path component seperator</param>
+        /// <returns>A string representation of this fully qualified name as expected by Boost Test standards.</returns>
+        public string ToString(string separator)
+        {
+            // Skip the Master Test Suite. Master Test Suite is omitted in qualified name.
+            return string.Join(separator, this.Path.Skip(1));
         }
 
         #endregion object overrides

--- a/BoostTestAdapter/Utility/QualifiedNameBuilder.cs
+++ b/BoostTestAdapter/Utility/QualifiedNameBuilder.cs
@@ -197,6 +197,19 @@ namespace BoostTestAdapter.Utility
         /// <returns>A QualifiedNameBuilder from the provided string.</returns>
         public static QualifiedNameBuilder FromString(string masterSuite, string name)
         {
+            return FromString(masterSuite, name, Separator);
+        }
+
+        /// <summary>
+        /// Factory method which creates a QualifiedNameBuilder
+        /// from an already existing qualified name string.
+        /// </summary>
+        /// <param name="masterSuite">The local name of the master test suite</param>
+        /// <param name="name">The qualified name</param>
+        /// <param name="separator">Path component seperator</param>
+        /// <returns>A QualifiedNameBuilder from the provided string.</returns>
+        public static QualifiedNameBuilder FromString(string masterSuite, string name, string separator)
+        {
             Utility.Code.Require(masterSuite, "masterSuite");
             Utility.Code.Require(name, "name");
 
@@ -204,7 +217,7 @@ namespace BoostTestAdapter.Utility
 
             builder.Push(masterSuite);
 
-            foreach (string part in name.Split(new string[] { Separator }, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string part in name.Split(new string[] { separator }, StringSplitOptions.RemoveEmptyEntries))
             {
                 builder.Push(part);
             }

--- a/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
+++ b/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
@@ -29,31 +29,24 @@ namespace BoostTestAdapter.Utility.VisualStudio
         /// <summary>
         /// TestSuite trait name
         /// </summary>
-        public static string TestSuiteTrait
-        {
-            get
-            {
-                return "TestSuite";
-            }
-        }
-        
+        public static string TestSuiteTrait { get; } = "TestSuite";
+
         /// <summary>
-        /// TestSuite trait name
+        /// Test Status (Enabled/Disabled) trait name
         /// </summary>
-        public static string StatusTrait
-        {
-            get
-            {
-                return "Status";
-            }
-        }
+        public static string StatusTrait { get; } = "Status";
+
+        /// <summary>
+        /// Boost.Test Test Path test property
+        /// </summary>
+        public static TestProperty TestPathProperty { get; } = TestProperty.Register("Boost.Test.Test.Path", "Boost.Test Test Path", typeof(string), typeof(VSTestModel));
 
         /// <summary>
         /// Converts forward slashes in a file path to backward slashes.
         /// </summary>
         /// <param name="path_in"> The input path</param>
         /// <returns>The output path, modified with backward slashes </returns>
-       
+
         private static string ConvertSlashes(string path_in)
         {
             return path_in.Replace('/', '\\');
@@ -80,6 +73,7 @@ namespace BoostTestAdapter.Utility.VisualStudio
                 return "Disabled";
             }
         }
+
 
         /// <summary>
         /// Converts a Boost.Test.Result.TestResult model into an equivalent
@@ -392,6 +386,25 @@ namespace BoostTestAdapter.Utility.VisualStudio
 
             // Only provide a single memory leak error if the test succeeded successfully (i.e. all asserts passed)
             return (errors.Any() ? errors : result.LogEntries.Where((e) => (e is LogEntryMemoryLeak)).Take(1));
+        }
+
+        /// <summary>
+        /// Identifies the Boost.Test test path of the provided Visual Studio test case
+        /// </summary>
+        /// <param name="testcase">Visual Studio test case (mapping to Boost.Test test case)</param>
+        /// <returns>The Boost.Test path of the test case which is identified by the Visual Studio counterpart</returns>
+        public static string GetBoostTestPath(this VSTestCase testcase)
+        {
+            return testcase.GetPropertyValue(TestPathProperty).ToString();
+        }
+
+        /// <summary>
+        /// Specifies the Boost.Test test path of the provided Visual Studio test case
+        /// </summary>
+        /// <param name="testcase">Visual Studio test case (mapping to Boost.Test test case)</param>
+        public static void SetBoostTestPath(this VSTestCase testcase, string value)
+        {
+            testcase.SetPropertyValue(TestPathProperty, value);
         }
     }
 }

--- a/BoostTestAdapterNunit/VSDiscoveryVisitorTest.cs
+++ b/BoostTestAdapterNunit/VSDiscoveryVisitorTest.cs
@@ -94,7 +94,7 @@ namespace BoostTestAdapterNunit
 
             Assert.That(test.Source, Is.EqualTo(source));
             Assert.That(test.ExecutorUri, Is.EqualTo(new Uri(BoostTestExecutor.ExecutorUriString)));
-            Assert.That(test.FullyQualifiedName, Is.EqualTo(expected.FullyQualifiedName));
+            Assert.That(test.FullyQualifiedName, Is.EqualTo(expected.GetFullyQualifiedName(".")));
 
             if (expected.Source != null)
             {


### PR DESCRIPTION
As noted by @jsutes in issue #79, Visual Studio seems to use a (undocumented?) protocol to create a hierarchy based on the FullyQualifiedName property of Visual Studio Test Case. This solution changes the slash-separated ('/') Boost.Test test paths to dot-separated ('.') names.

Note that this may cause a breaking change - users of `vstest.console` will need to outline tests in the `/Tests:` command line option using the new scheme. In addition, no guarantees can be made with regards to correct visualisation of Boost.Test test cases which are manually registered via a user-specified (string) name (which may contain dots).