### PR TITLE
Avoid Debug Symbol Search

### DIFF
--- a/BoostTestAdapter/Boost/Runner/BoostTest162Runner.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTest162Runner.cs
@@ -41,6 +41,8 @@ namespace BoostTestAdapter.Boost.Runner
 
         public bool ListContentSupported => this.Runner.ListContentSupported;
 
+        public bool VersionSupported => this.Runner.VersionSupported;
+
         public string Source => this.Runner.Source;
 
         public int Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext executionContext)

--- a/BoostTestAdapter/Boost/Runner/BoostTest162Runner.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTest162Runner.cs
@@ -39,11 +39,9 @@ namespace BoostTestAdapter.Boost.Runner
 
         #region IBoostTestRunner
 
-        public bool ListContentSupported => this.Runner.ListContentSupported;
-
-        public bool VersionSupported => this.Runner.VersionSupported;
-
         public string Source => this.Runner.Source;
+
+        public IBoostTestRunnerCapabilities Capabilities => this.Runner.Capabilities;
 
         public int Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext executionContext)
         {

--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
@@ -97,6 +97,29 @@ namespace BoostTestAdapter.Boost.Runner
             }
         }
 
+        public virtual bool VersionSupported
+        {
+            get
+            {
+                try
+                {
+                    using (DebugHelper dbgHelp = new DebugHelper(this.TestRunnerExecutable))
+                    {
+                        return dbgHelp.ContainsSymbol("boost::unit_test::runtime_config::VERSION")          // Boost 1.63
+                            || dbgHelp.ContainsSymbol("boost::unit_test::runtime_config::btrt_version");    // Boost 1.64
+                    }
+                }
+                catch (Win32Exception ex)
+                {
+                    Logger.Exception(ex, Resources.CouldNotCreateDbgHelp, this.Source);
+                }
+
+                return false;
+            }
+        }
+
+        #endregion IBoostTestRunner
+        
         /// <summary>
         /// Provides a ProcessExecutionContextArgs structure containing the necessary information to launch the test process.
         /// Aggregates the BoostTestRunnerCommandLineArgs structure with the command-line arguments specified at configuration stage.
@@ -116,8 +139,6 @@ namespace BoostTestAdapter.Boost.Runner
                 EnvironmentVariables = args.Environment
             };
         }
-
-        #endregion IBoostTestRunner
 
         /// <summary>
         /// Monitors the provided process for the specified timeout.

--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerCapabilities.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerCapabilities.cs
@@ -1,0 +1,21 @@
+﻿// (C) Copyright 2015 ETAS GmbH (http://www.etas.com/)
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+namespace BoostTestAdapter.Boost.Runner
+{
+    /// <summary>
+    /// Default implementation of IBoostTestRunnerCapabilities
+    /// </summary>
+    public class BoostTestRunnerCapabilities : IBoostTestRunnerCapabilities
+    {
+        #region IBoostTestRunnerCapabilities
+
+        public bool ListContent { get; set; } = false;
+
+        public bool Version { get; set; } = false;
+
+        #endregion
+    }
+}

--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerCapabilityOverride.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerCapabilityOverride.cs
@@ -1,0 +1,57 @@
+﻿// (C) Copyright 2015 ETAS GmbH (http://www.etas.com/)
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+using BoostTestAdapter.Utility;
+using BoostTestAdapter.Utility.ExecutionContext;
+
+namespace BoostTestAdapter.Boost.Runner
+{
+    /// <summary>
+    /// An IBoostTestRunner wrapper which overrides the capabilities
+    /// of the underlying Boost.Test runner
+    /// </summary>
+    public class BoostTestRunnerCapabilityOverride : IBoostTestRunner
+    {
+        #region Constructors
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="runner">The underlying Boost.Test runner</param>
+        /// <param name="capabilities">The overriden capability set of the Boost.Test runner</param>
+        public BoostTestRunnerCapabilityOverride(IBoostTestRunner runner, IBoostTestRunnerCapabilities capabilities)
+        {
+            Code.Require(runner, "runner");
+            Code.Require(capabilities, "capabilities");
+
+            Runner = runner;
+            Capabilities = capabilities;
+        }
+        
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Underlying Boost.Test runner instance
+        /// </summary>
+        public IBoostTestRunner Runner { get; private set; }
+
+        #endregion
+
+        #region IBoostTestRunner
+        
+        public IBoostTestRunnerCapabilities Capabilities { get; private set; }
+
+        public string Source => Runner.Source;
+
+        public int Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext executionContext)
+        {
+            return Runner.Execute(args, settings, executionContext);
+        }
+
+        #endregion
+    }
+}

--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
@@ -174,6 +174,8 @@ namespace BoostTestAdapter.Boost.Runner
         internal const string ListContentArg = "--list_content";
         internal const string HelpArg = "--help";
 
+        internal const string VersionArg = "--version";
+
         private const string TestSeparator = ",";
 
         private const char ArgSeparator = ' ';
@@ -229,6 +231,7 @@ namespace BoostTestAdapter.Boost.Runner
             this.SavePattern = false;
             this.ListContent = null;
             this.Help = false;
+            this.Version = false;
 
             this.Environment = new Dictionary<string, string>();
         }
@@ -351,7 +354,7 @@ namespace BoostTestAdapter.Boost.Runner
         public string AutoStartDebug { get; set; }
 
         /// <summary>
-        /// Flag which displays Boost UTF test information in standard out.
+        /// Flag which displays Boost.Test test information in standard out.
         /// </summary>
         public bool BuildInfo { get; set; }
 
@@ -367,7 +370,7 @@ namespace BoostTestAdapter.Boost.Runner
         public bool ColorOutput { get; set; }
 
         /// <summary>
-        /// Determines the result code the Boost UTF uses on exit.
+        /// Determines the result code the Boost.Test uses on exit.
         /// </summary>
         public bool ResultCode { get; set; }
 
@@ -382,7 +385,7 @@ namespace BoostTestAdapter.Boost.Runner
         public bool UseAltStack { get; set; }
 
         /// <summary>
-        /// Instructs the Boost UTF to break on floating-point exceptions.
+        /// Instructs the Boost.Test to break on floating-point exceptions.
         /// </summary>
         public bool DetectFPExceptions { get; set; }
 
@@ -393,7 +396,7 @@ namespace BoostTestAdapter.Boost.Runner
         public bool SavePattern { get; set; }
 
         /// <summary>
-        /// The Boost UTF lists all tests which are to be executed without actually executing the tests.
+        /// The Boost.Test lists all tests which are to be executed without actually executing the tests.
         /// </summary>
         /// <remarks>Introduced in Boost 1.59 / Boost Test 3</remarks>
         public ListContentFormat? ListContent { get; set; }
@@ -402,6 +405,11 @@ namespace BoostTestAdapter.Boost.Runner
         /// Help output.
         /// </summary>
         public bool Help { get; set; }
+
+        /// <summary>
+        /// Version information output.
+        /// </summary>
+        public bool Version { get; set; }
 
         /// <summary>
         /// Path (relative to the WorkingDirectory) to the report file which will host the standard output content.
@@ -448,7 +456,16 @@ namespace BoostTestAdapter.Boost.Runner
             {
                 AddArgument(HelpArg, args);
 
-                // return immediately since Boost UTF should ignore the rest of the arguments
+                // return immediately since Boost.Test should ignore the rest of the arguments
+                return AppendRedirection(args).ToString().TrimEnd();
+            }
+
+            // --version
+            if (this.Version)
+            {
+                AddArgument(VersionArg, args);
+
+                // return immediately since Boost.Test should ignore the rest of the arguments
                 return AppendRedirection(args).ToString().TrimEnd(null);
             }
 
@@ -457,7 +474,7 @@ namespace BoostTestAdapter.Boost.Runner
             {
                 AddArgument(ListContentArg, ListContentFormatToString(this.ListContent.Value), args);
 
-                // return immediately since Boost UTF should ignore the rest of the arguments
+                // return immediately since Boost.Test should ignore the rest of the arguments
                 return AppendRedirection(args).ToString().TrimEnd(null);
             }
 
@@ -809,6 +826,8 @@ namespace BoostTestAdapter.Boost.Runner
             clone.DetectFPExceptions = this.DetectFPExceptions;
             clone.SavePattern = this.SavePattern;
             clone.ListContent = this.ListContent;
+            clone.Help = this.Help;
+            clone.Version = this.Version;
 
             return clone;
         }

--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerFactoryOptions.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerFactoryOptions.cs
@@ -3,6 +3,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+using System;
 using BoostTestAdapter.Settings;
 
 namespace BoostTestAdapter.Boost.Runner
@@ -10,8 +11,13 @@ namespace BoostTestAdapter.Boost.Runner
     /// <summary>
     /// Aggregates all options for BoostTestRunnerFactory
     /// </summary>
-    public class BoostTestRunnerFactoryOptions
+    public class BoostTestRunnerFactoryOptions : IEquatable<BoostTestRunnerFactoryOptions>
     {
+        /// <summary>
+        /// Version identifier which forces the factory to assume a Boost.Test version
+        /// </summary>
+        public Version ForcedBoostTestVersion { get; set; } = null;
+
         /// <summary>
         /// Flag determining if Boost Test available in Boost 1.62 is in use
         /// </summary>
@@ -20,6 +26,38 @@ namespace BoostTestAdapter.Boost.Runner
         /// <summary>
         /// Settings for external test runner use
         /// </summary>
-        public ExternalBoostTestRunnerSettings ExternalTestRunnerSettings { get; set; }
+        public ExternalBoostTestRunnerSettings ExternalTestRunnerSettings { get; set; } = null;
+
+        #region Object
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as BoostTestRunnerFactoryOptions);
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = 21;
+
+            hash = hash * 33 + ((ForcedBoostTestVersion == null) ? 0 : ForcedBoostTestVersion.GetHashCode());
+            hash = hash * 33 + UseBoost162Workaround.GetHashCode();
+            hash = hash * 33 + ((ExternalTestRunnerSettings == null) ? 0 : ExternalTestRunnerSettings.GetHashCode());
+
+            return hash;
+        }
+
+        #endregion
+
+        #region IEquatable<BoostTestRunnerFactoryOptions>
+
+        public bool Equals(BoostTestRunnerFactoryOptions other)
+        {
+            return (other != null) &&
+                ((ForcedBoostTestVersion == other.ForcedBoostTestVersion) || ((ForcedBoostTestVersion != null) && ForcedBoostTestVersion.Equals(other.ForcedBoostTestVersion))) &&
+                (UseBoost162Workaround == other.UseBoost162Workaround) &&
+                ((ExternalTestRunnerSettings == other.ExternalTestRunnerSettings) || ((ExternalTestRunnerSettings != null) && ExternalTestRunnerSettings.Equals(other.ExternalTestRunnerSettings)));
+        }
+
+        #endregion
     }
 }

--- a/BoostTestAdapter/Boost/Runner/CachingBoostTestRunnerFactory.cs
+++ b/BoostTestAdapter/Boost/Runner/CachingBoostTestRunnerFactory.cs
@@ -1,0 +1,68 @@
+﻿// (C) Copyright 2015 ETAS GmbH (http://www.etas.com/)
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+using System;
+using System.Collections.Generic;
+
+namespace BoostTestAdapter.Boost.Runner
+{
+    /// <summary>
+    /// An IBoostTestRunnerFactory wrapper which caches produced test runners
+    /// </summary>
+    public class CachingBoostTestRunnerFactory : IBoostTestRunnerFactory
+    {
+        #region Constructors
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="factory">The base underlying factory which will produce the Boost.Test runners</param>
+        public CachingBoostTestRunnerFactory(IBoostTestRunnerFactory factory)
+        {
+            BaseFactory = factory;
+
+            _cache = new Dictionary<Tuple<string, BoostTestRunnerFactoryOptions>, IBoostTestRunner>();
+        }
+
+        #endregion
+
+        #region Members
+
+        /// <summary>
+        /// Boost.Test runner cache
+        /// </summary>
+        private readonly Dictionary<Tuple<string, BoostTestRunnerFactoryOptions>, IBoostTestRunner> _cache;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Base (wrapped) factory
+        /// </summary>
+        public IBoostTestRunnerFactory BaseFactory { get; private set; }
+
+        #endregion
+
+        #region IBoostTestRunnerFactory
+        
+        public IBoostTestRunner GetRunner(string identifier, BoostTestRunnerFactoryOptions options)
+        {
+            var key = Tuple.Create(identifier, options);
+
+            IBoostTestRunner runner = null;
+
+            if (!_cache.TryGetValue(key, out runner))
+            {
+                runner = BaseFactory.GetRunner(identifier, options);
+                _cache.Add(key, runner);
+            }
+            
+            return runner;
+        }
+
+        #endregion
+    }
+}

--- a/BoostTestAdapter/Boost/Runner/DefaultBoostTestRunnerFactory.cs
+++ b/BoostTestAdapter/Boost/Runner/DefaultBoostTestRunnerFactory.cs
@@ -3,7 +3,10 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+using System;
 using System.IO;
+using System.Text.RegularExpressions;
+
 using BoostTestAdapter.Settings;
 
 namespace BoostTestAdapter.Boost.Runner
@@ -13,6 +16,34 @@ namespace BoostTestAdapter.Boost.Runner
     /// </summary>
     public class DefaultBoostTestRunnerFactory : IBoostTestRunnerFactory
     {
+        #region Constants
+
+        /// <summary>
+        /// 'Fast-path' filename pattern. Such filenames are assumed to be valid Boost.Test modules which support '--list_content'.
+        /// </summary>
+        private static readonly Regex _forceListContentExtensionPattern = new Regex(@"test\.boost(?:d)?\.exe$", RegexOptions.IgnoreCase);
+
+        #region Properties
+
+        /// <summary>
+        /// Boost 1.59 version identifier
+        /// </summary>
+        public static readonly Version Boost159 = new Version(1, 59);
+
+        /// <summary>
+        /// Boost 1.62 version identifier
+        /// </summary>
+        public static readonly Version Boost162 = new Version(1, 62);
+
+        /// <summary>
+        /// Boost 1.63 version identifier
+        /// </summary>
+        public static readonly Version Boost163 = new Version(1, 63);
+
+        #endregion
+
+        #endregion
+
         #region IBoostTestRunnerFactory
 
         /// <summary>
@@ -38,15 +69,40 @@ namespace BoostTestAdapter.Boost.Runner
                 runner = GetInternalTestRunner(identifier);
             }
 
-            // Apply Boost 1.62 workaround
-            if ((runner != null) && (options != null) && (options.UseBoost162Workaround))
+            if (runner != null)
             {
-                runner = new BoostTest162Runner(runner);
+                // Apply specific Boost 1.62 workaround
+                if (GetBoost162Workaround(options))
+                {
+                    runner = new BoostTest162Runner(runner);
+                }
+                
+                // Force the use of a specific Boost.Test runner implementation
+                Version version = GetBoostTestVersion(identifier, options);
+
+                if (version != null)
+                {
+                    // Assume runner capabilities based on provided version
+                    var capabilities = new BoostTestRunnerCapabilities
+                    {
+                        ListContent = (version >= Boost159),
+                        Version = (version >= Boost163)
+                    };
+
+                    runner = new BoostTestRunnerCapabilityOverride(runner, capabilities);
+                }
             }
 
             return runner;
         }
 
+        #endregion IBoostTestRunnerFactory
+
+        /// <summary>
+        /// Generates a suitable test runner for the provided source
+        /// </summary>
+        /// <param name="source">The test module file path</param>
+        /// <returns>An test runner for the provided source or null if one cannot be produced</returns>
         private static IBoostTestRunner GetInternalTestRunner(string source)
         {
             switch (Path.GetExtension(source))
@@ -57,6 +113,12 @@ namespace BoostTestAdapter.Boost.Runner
             return null;
         }
 
+        /// <summary>
+        /// Generates a suitable external test runner for the provided source
+        /// </summary>
+        /// <param name="source">The test module file path</param>
+        /// <param name="settings">External test runner settings</param>
+        /// <returns>An external test runner for the provided source or null if one cannot be produced</returns>
         private static IBoostTestRunner GetExternalTestRunner(string source, ExternalBoostTestRunnerSettings settings)
         {
             Utility.Code.Require(settings, "settings");
@@ -69,6 +131,34 @@ namespace BoostTestAdapter.Boost.Runner
             return null;
         }
 
-        #endregion IBoostTestRunnerFactory
+        /// <summary>
+        /// Acquires the Boost.Test from the settings and test module file path
+        /// </summary>
+        /// <param name="source">The test module file path</param>
+        /// <param name="options">Test runner factory options</param>
+        /// <returns>The specified Boost.Test version or null if the version cannot be assumed from the provided details</returns>
+        private static Version GetBoostTestVersion(string source, BoostTestRunnerFactoryOptions options)
+        {
+            Version version = options?.ForcedBoostTestVersion;
+
+            // Convention over configuration. Assume test runners utilising such an
+            // extension pattern to be Boost 1.59 capable test runners.
+            if ((version == null) && _forceListContentExtensionPattern.IsMatch(source))
+            {
+                version = Boost159;
+            }
+
+            return version;
+        }
+
+        /// <summary>
+        /// Determines whether or not the Boost 1.62 workaround is to be applied
+        /// </summary>
+        /// <param name="options">Test runner factory options</param>
+        /// <returns>true if the Boost 1.62 workaround should be applied; false otherwise</returns>
+        private static bool GetBoost162Workaround(BoostTestRunnerFactoryOptions options)
+        {
+            return (options != null) && (options.UseBoost162Workaround || (options.ForcedBoostTestVersion == Boost162));
+        }
     }
 }

--- a/BoostTestAdapter/Boost/Runner/ExternalBoostTestRunner.cs
+++ b/BoostTestAdapter/Boost/Runner/ExternalBoostTestRunner.cs
@@ -50,7 +50,10 @@ namespace BoostTestAdapter.Boost.Runner
 
         public override string Source
         {
-            get { return this._source; }
+            get
+            {
+                return this._source;
+            }
         }
 
         public override bool ListContentSupported
@@ -60,6 +63,8 @@ namespace BoostTestAdapter.Boost.Runner
                 return (Settings.DiscoveryMethodType == DiscoveryMethodType.DiscoveryListContent);
             }
         }
+
+        public override bool VersionSupported { get; } = false;
 
         #endregion IBoostTestRunner
 

--- a/BoostTestAdapter/Boost/Runner/ExternalBoostTestRunner.cs
+++ b/BoostTestAdapter/Boost/Runner/ExternalBoostTestRunner.cs
@@ -56,16 +56,18 @@ namespace BoostTestAdapter.Boost.Runner
             }
         }
 
-        public override bool ListContentSupported
+        public override IBoostTestRunnerCapabilities Capabilities
         {
             get
             {
-                return (Settings.DiscoveryMethodType == DiscoveryMethodType.DiscoveryListContent);
+                return new BoostTestRunnerCapabilities
+                {
+                    ListContent = (Settings.DiscoveryMethodType == DiscoveryMethodType.DiscoveryListContent),
+                    Version = false
+                };
             }
         }
-
-        public override bool VersionSupported { get; } = false;
-
+        
         #endregion IBoostTestRunner
 
         #region BoostTestRunnerBase

--- a/BoostTestAdapter/Boost/Runner/IBoostTestRunner.cs
+++ b/BoostTestAdapter/Boost/Runner/IBoostTestRunner.cs
@@ -28,13 +28,8 @@ namespace BoostTestAdapter.Boost.Runner
         string Source { get; }
 
         /// <summary>
-        /// Determines if the test runner provides --list_content capabilities.
+        /// Determines the test runner's capability set
         /// </summary>
-        bool ListContentSupported { get; }
-
-        /// <summary>
-        /// Determines if the test runner provides --version capabilities.
-        /// </summary>
-        bool VersionSupported { get; }
+        IBoostTestRunnerCapabilities Capabilities { get; }
     }
 }

--- a/BoostTestAdapter/Boost/Runner/IBoostTestRunner.cs
+++ b/BoostTestAdapter/Boost/Runner/IBoostTestRunner.cs
@@ -31,5 +31,10 @@ namespace BoostTestAdapter.Boost.Runner
         /// Determines if the test runner provides --list_content capabilities.
         /// </summary>
         bool ListContentSupported { get; }
+
+        /// <summary>
+        /// Determines if the test runner provides --version capabilities.
+        /// </summary>
+        bool VersionSupported { get; }
     }
 }

--- a/BoostTestAdapter/Boost/Runner/IBoostTestRunnerCapabilities.cs
+++ b/BoostTestAdapter/Boost/Runner/IBoostTestRunnerCapabilities.cs
@@ -1,0 +1,23 @@
+﻿// (C) Copyright 2015 ETAS GmbH (http://www.etas.com/)
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+namespace BoostTestAdapter.Boost.Runner
+{
+    /// <summary>
+    /// Aggregation of a Boost.Test runner's capabilities
+    /// </summary>
+    public interface IBoostTestRunnerCapabilities
+    {
+        /// <summary>
+        /// Determines if the Boost.Test runner supports the '--list_content' command-line argument
+        /// </summary>
+        bool ListContent { get; }
+        
+        /// <summary>
+        /// Determines if the Boost.Test runner supports the '--version' command-line argument
+        /// </summary>
+        bool Version { get; }
+    }
+}

--- a/BoostTestAdapter/BoostTestAdapter.csproj
+++ b/BoostTestAdapter/BoostTestAdapter.csproj
@@ -149,6 +149,7 @@
     <Compile Include="TestBatch\SourceTestBatchStrategy.cs" />
     <Compile Include="TestBatch\TestBatchStrategy.cs" />
     <Compile Include="TestBatch\TestSuiteTestBatchStrategy.cs" />
+    <Compile Include="Utility\ByteArrayUtils.cs" />
     <Compile Include="Utility\Code.cs" />
     <Compile Include="Utility\CommandEvaluator.cs" />
     <Compile Include="Utility\CommandLine.cs" />

--- a/BoostTestAdapter/BoostTestAdapter.csproj
+++ b/BoostTestAdapter/BoostTestAdapter.csproj
@@ -75,6 +75,10 @@
   <ItemGroup>
     <Compile Include="BoostTestDiscoverer.cs" />
     <Compile Include="Boost\Runner\BoostTest162Runner.cs" />
+    <Compile Include="Boost\Runner\BoostTestRunnerCapabilities.cs" />
+    <Compile Include="Boost\Runner\BoostTestRunnerCapabilityOverride.cs" />
+    <Compile Include="Boost\Runner\CachingBoostTestRunnerFactory.cs" />
+    <Compile Include="Boost\Runner\IBoostTestRunnerCapabilities.cs" />
     <Compile Include="Discoverers\BoostTestDiscovererUtility.cs" />
     <Compile Include="Discoverers\BoostTestDiscovererFactory.cs" />
     <Compile Include="BoostTestExecutor.cs" />
@@ -160,6 +164,7 @@
     <Compile Include="Utility\TemporaryFile.cs" />
     <Compile Include="Utility\TestPathGenerator.cs" />
     <Compile Include="Utility\TestRun.cs" />
+    <Compile Include="Utility\TimedScope.cs" />
     <Compile Include="Utility\VisualStudio\DefaultTestCaseDiscoverySink.cs" />
     <Compile Include="Utility\VisualStudio\VSTestModel.cs" />
     <Compile Include="Utility\XmlReaderHelper.cs" />

--- a/BoostTestAdapter/BoostTestAdapterSettings.xsd
+++ b/BoostTestAdapter/BoostTestAdapterSettings.xsd
@@ -38,6 +38,7 @@
           </xsd:restriction>
         </xsd:simpleType>
       </xsd:element>
+      <xsd:element name="ForceBoostVersion" minOccurs="0" type="VersionType" />
     </xsd:all>
   </xsd:complexType>
 
@@ -91,4 +92,10 @@
     </xsd:sequence>
   </xsd:complexType>
 
+  <xsd:simpleType name="VersionType" final="restriction">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="\d+(\.\d+(.\d+)?)?"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+    
 </xsd:schema>

--- a/BoostTestAdapter/BoostTestDiscoverer.cs
+++ b/BoostTestAdapter/BoostTestDiscoverer.cs
@@ -48,15 +48,13 @@ namespace BoostTestAdapter
         }
 
         #endregion
-
-
+        
         #region Members
 
         private readonly IBoostTestDiscovererFactory _boostTestDiscovererFactory;
 
         #endregion
-
-
+        
         #region ITestDiscoverer
 
         /// <summary>

--- a/BoostTestAdapter/BoostTestExecutor.cs
+++ b/BoostTestAdapter/BoostTestExecutor.cs
@@ -66,8 +66,8 @@ namespace BoostTestAdapter
         public BoostTestExecutor()
         {
             _testRunnerFactory = new DefaultBoostTestRunnerFactory();
-            _boostTestDiscovererFactory = new BoostTestDiscovererFactory(_testRunnerFactory);
             _packageServiceFactory = new DefaultBoostTestPackageServiceFactory();
+            _boostTestDiscovererFactory = new BoostTestDiscovererFactory(_testRunnerFactory, _packageServiceFactory);
 
             _cancelled = false;
         }

--- a/BoostTestAdapter/Discoverers/BoostTestDiscovererFactory.cs
+++ b/BoostTestAdapter/Discoverers/BoostTestDiscovererFactory.cs
@@ -7,32 +7,23 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 using BoostTestAdapter.Discoverers;
 using BoostTestAdapter.Boost.Runner;
 using BoostTestAdapter.Settings;
+using BoostTestAdapter.Utility.VisualStudio;
 
 namespace BoostTestAdapter
 {
     class BoostTestDiscovererFactory : IBoostTestDiscovererFactory
     {
-        #region Constants
-
-        /// <summary>
-        /// Default 'ForceListContent' filename pattern. Such filenames are assumed to be valid Boost.Test modules by default.
-        /// </summary>
-        private static readonly Regex _forceListContentExtensionPattern = new Regex(@"test\.boost(?:d)?\.exe$", RegexOptions.IgnoreCase);
-        
-        #endregion 
-
         #region Constructors
 
         /// <summary>
         /// Default constructor. The default implementation of IBoostTestRunnerFactory is provided.
         /// </summary>
         public BoostTestDiscovererFactory()
-            : this(new DefaultBoostTestRunnerFactory())
+            : this(new CachingBoostTestRunnerFactory(new DefaultBoostTestRunnerFactory()), new DefaultBoostTestPackageServiceFactory())
         {
         }
 
@@ -40,9 +31,11 @@ namespace BoostTestAdapter
         /// Constructor.
         /// </summary>
         /// <param name="factory">A custom IBoostTestRunnerFactory implementation.</param>
-        public BoostTestDiscovererFactory(IBoostTestRunnerFactory factory)
+        /// <param name="packageServiceFactory">A custom implementation of IBoostTestPackageServiceFactory</param>
+        public BoostTestDiscovererFactory(IBoostTestRunnerFactory factory, IBoostTestPackageServiceFactory provider)
         {
             _factory = factory;
+            _boostTestPackage = provider;
         }
 
         #endregion
@@ -50,6 +43,7 @@ namespace BoostTestAdapter
         #region Members
 
         private readonly IBoostTestRunnerFactory _factory;
+        private readonly IBoostTestPackageServiceFactory _boostTestPackage;
 
         #endregion
 
@@ -92,13 +86,13 @@ namespace BoostTestAdapter
                 }
 
                 // Skip modules which are not .exe
-                if (string.Compare(extension, BoostTestDiscoverer.ExeExtension, true) != 0)
+                if (string.Compare(extension, BoostTestDiscoverer.ExeExtension, StringComparison.OrdinalIgnoreCase) != 0)
                 {
                     continue;
                 }
 
                 // Ensure that the source is a Boost.Test module if it supports '--list_content'
-                if (((settings.ForceListContent) || IsListContentSupported(source, settings)))
+                if (IsListContentSupported(source, settings))
                 {
                     listContentDiscovererSources.Add(source);
                 }
@@ -116,7 +110,7 @@ namespace BoostTestAdapter
             if (listContentDiscovererSources.Any())
                 discoverers.Add(new FactoryResult()
                 {
-                    Discoverer = new ListContentDiscoverer(),
+                    Discoverer = new ListContentDiscoverer(_factory, _boostTestPackage),
                     Sources = listContentDiscovererSources
                 });
      
@@ -133,15 +127,9 @@ namespace BoostTestAdapter
         /// <returns>true if the source has list content capabilities; false otherwise</returns>
         private bool IsListContentSupported(string source, BoostTestAdapterSettings settings)
         {
-            BoostTestRunnerFactoryOptions options = new BoostTestRunnerFactoryOptions()
-            {
-                ExternalTestRunnerSettings = settings.ExternalTestRunner
-            };
+            var runner = _factory.GetRunner(source, settings.TestRunnerFactoryOptions);
 
-            IBoostTestRunner runner = _factory.GetRunner(source, options);
-
-            // Convention over configuration. Assume test runners utilising such an extension pattern
-            return (runner != null) && (_forceListContentExtensionPattern.IsMatch(source) || runner.ListContentSupported);
+            return (runner != null) && (runner.Capabilities.ListContent);
         }
     }
 }

--- a/BoostTestAdapter/Discoverers/ListContentDiscoverer.cs
+++ b/BoostTestAdapter/Discoverers/ListContentDiscoverer.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace BoostTestAdapter.Discoverers
 {
@@ -135,7 +136,7 @@ namespace BoostTestAdapter.Discoverers
                             TestFramework framework = deserialiser.Deserialise(reader);
                             if ((framework != null) && (framework.MasterTestSuite != null))
                             {
-                                framework.MasterTestSuite.Apply(new VSDiscoveryVisitor(source, discoverySink));
+                                framework.MasterTestSuite.Apply(new VSDiscoveryVisitor(source, GetVersion(runner), discoverySink));
                             }
                         }
                     }
@@ -144,6 +145,52 @@ namespace BoostTestAdapter.Discoverers
                 {
                     Logger.Exception(ex, Resources.DiscoveryExceptionFor, source, ex.Message, ex.HResult);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Regular expression pattern for extracting Boost version from Boost.Test --version output
+        /// </summary>
+        private static readonly Regex _versionPattern = new Regex(@"Compiled from Boost version (\d+\.\d+.\d+)");
+
+        /// <summary>
+        /// Identify the version (if possible) of the Boost.Test module
+        /// </summary>
+        /// <param name="runner">The Boost.Test module</param>
+        /// <returns>The Boost version of the Boost.Test module or the empty string if the version cannot be retrieved</returns>
+        private static string GetVersion(IBoostTestRunner runner)
+        {
+            if (!runner.VersionSupported)
+            {
+                return string.Empty;
+            }
+
+            using (TemporaryFile output = new TemporaryFile(TestPathGenerator.Generate(runner.Source, ".version.stderr.log")))
+            {
+                BoostTestRunnerSettings settings = new BoostTestRunnerSettings();
+                BoostTestRunnerCommandLineArgs args = new BoostTestRunnerCommandLineArgs()
+                {
+                    Version = true,
+                    StandardErrorFile = output.Path
+                };
+
+                int resultCode = EXIT_SUCCESS;
+
+                using (var context = new DefaultProcessExecutionContext())
+                {
+                    resultCode = runner.Execute(args, settings, context);
+                }
+
+                if (resultCode != EXIT_SUCCESS)
+                {
+                    Logger.Error("--version for {0} failed with exit code {1}. Skipping.", runner.Source, resultCode);
+                    return string.Empty;
+                }
+
+                var info = File.ReadAllText(args.StandardErrorFile, System.Text.Encoding.ASCII);
+
+                var match = _versionPattern.Match(info);
+                return (match.Success) ? match.Groups[1].Value : string.Empty;
             }
         }
 

--- a/BoostTestAdapter/Discoverers/VSDiscoveryVisitor.cs
+++ b/BoostTestAdapter/Discoverers/VSDiscoveryVisitor.cs
@@ -33,10 +33,22 @@ namespace BoostTestAdapter.Discoverers
         /// <param name="source">The source test module which contains the discovered tests</param>
         /// <param name="sink">The ITestCaseDiscoverySink which will have tests registered with</param>
         public VSDiscoveryVisitor(string source, ITestCaseDiscoverySink sink)
+            : this(source, string.Empty, sink)
+        {
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="source">The source test module which contains the discovered tests</param>
+        /// <param name="version">The source test module Boost.Test version</param>
+        /// <param name="sink">The ITestCaseDiscoverySink which will have tests registered with</param>
+        public VSDiscoveryVisitor(string source, string version, ITestCaseDiscoverySink sink)
         {
             Code.Require(sink, "sink");
 
             this.Source = source;
+            this.Version = version;
             this.DiscoverySink = sink;
             this.OutputLog = true;
         }
@@ -45,6 +57,11 @@ namespace BoostTestAdapter.Discoverers
         /// The test module source file path
         /// </summary>
         public string Source { get; private set; }
+
+        /// <summary>
+        /// The test module version
+        /// </summary>
+        public string Version { get; private set; }
 
         /// <summary>
         /// Whether the module should output to the logger regarding relative paths
@@ -155,6 +172,12 @@ namespace BoostTestAdapter.Discoverers
                 // Test cases inherit the labels of parent test units
                 // Reference: http://www.boost.org/doc/libs/1_60_0/libs/test/doc/html/boost_test/tests_organization/tests_grouping.html
                 unit = unit.Parent;
+            }
+
+            // Record Boost version if available
+            if (!string.IsNullOrEmpty(this.Version))
+            {
+                test.SetPropertyValue(VSTestModel.VersionProperty, this.Version);
             }
 
             return test;

--- a/BoostTestAdapter/Discoverers/VSDiscoveryVisitor.cs
+++ b/BoostTestAdapter/Discoverers/VSDiscoveryVisitor.cs
@@ -85,7 +85,7 @@ namespace BoostTestAdapter.Discoverers
                 {
                     // NOTE Since we have asserted that the suite is a BOOST_DATA_TEST_CASE,
                     //      all child instances are to be of type TestCase
-                    
+
                     var displayName = testSuite.Name + '/' + child.Name;
                     Visit((TestCase)child, displayName);
                 }

--- a/BoostTestAdapter/Resources.Designer.cs
+++ b/BoostTestAdapter/Resources.Designer.cs
@@ -115,7 +115,7 @@ namespace BoostTestAdapter {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not locate debug symbols for &apos;{0}&apos;. To make use of &apos;--list_content&apos; discovery, ensure that debug symbols are available or make use of &apos;&lt;ForceListContent&gt;&apos; via a .runsettings file..
+        ///   Looks up a localized string similar to Could not locate symbols for &apos;{0}&apos;. To make use of &apos;--list_content&apos; discovery, ensure that symbols are available or make use of &apos;&lt;ForceListContent&gt;&apos; via a .runsettings file..
         /// </summary>
         internal static string CouldNotLocateDebugSymbols {
             get {

--- a/BoostTestAdapter/Resources.resx
+++ b/BoostTestAdapter/Resources.resx
@@ -143,7 +143,7 @@
     <comment>{0} represents a test executable file name</comment>
   </data>
   <data name="CouldNotLocateDebugSymbols" xml:space="preserve">
-    <value>Could not locate debug symbols for '{0}'. To make use of '--list_content' discovery, ensure that debug symbols are available or make use of '&lt;ForceListContent&gt;' via a .runsettings file.</value>
+    <value>Could not locate symbols for '{0}'. To make use of '--list_content' discovery, ensure that symbols are available or make use of '&lt;ForceListContent&gt;' via a .runsettings file.</value>
     <comment>{0} represents a test executable file name</comment>
   </data>
   <data name="Debugging" xml:space="preserve">

--- a/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
+++ b/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
@@ -7,6 +7,7 @@
 
 using BoostTestAdapter.Boost.Runner;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Xml;
@@ -45,9 +46,7 @@ namespace BoostTestAdapter.Settings
             this.DetectFloatingPointExceptions = false;
 
             this.TestBatchStrategy = TestBatch.Strategy.TestCase;
-
-            this.ForceListContent = false;
-
+            
             this.WorkingDirectory = null;
 
             this.EnableStdOutRedirection = true;
@@ -61,6 +60,8 @@ namespace BoostTestAdapter.Settings
             this.TestRunnerFactoryOptions = new BoostTestRunnerFactoryOptions();
 
             this.PostTestDelay = 0;
+
+            this.ForceBoostVersion = null;
 
             this.ParentVSProcessId = -1;
         }
@@ -163,8 +164,24 @@ namespace BoostTestAdapter.Settings
         /// <summary>
         /// Forces the use of 'list_content=DOT' even if the test module is not recognized as a safe module.
         /// </summary>
-        [DefaultValue(false)]
-        public bool ForceListContent { get; set; }
+        /// <remarks>Deprecated. This configuration element is superseded by '<ForceBoostVersion>'</remarks>
+        [DefaultValue(false), Obsolete("This configuration element is superseded by '<ForceBoostVersion>'")]
+        public bool ForceListContent
+        {
+            get
+            {
+                return (TestRunnerFactoryOptions.ForcedBoostTestVersion != null) &&
+                    (TestRunnerFactoryOptions.ForcedBoostTestVersion >= DefaultBoostTestRunnerFactory.Boost159);
+            }
+
+            set
+            {
+                if (value && (TestRunnerFactoryOptions.ForcedBoostTestVersion == null))
+                {
+                    TestRunnerFactoryOptions.ForcedBoostTestVersion = DefaultBoostTestRunnerFactory.Boost159;
+                }
+            }
+        }
 
         /// <summary>
         /// Determines the working directory which is to be used during the discovery/execution of the test module. If the test module is executed within a Visual Studio test adapter session, the Working Directory defined in the 'Debug' property sheet configuration overrides this value.
@@ -218,6 +235,24 @@ namespace BoostTestAdapter.Settings
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "PostTest")]
         [DefaultValue(0)]
         public int PostTestDelay { get; set; }
+
+        /// <summary>
+        /// Assumes/Forces the use of a specific Boost version even if the test module is not recognized as a safe module.
+        /// </summary>
+        /// <remarks>Assumes Boost.Test capabilities from the specified version. This configuration element supersedes '<ForceListContent>'</remarks>
+        [DefaultValue(null)]
+        public string ForceBoostVersion
+        {
+            get
+            {
+                return (TestRunnerFactoryOptions.ForcedBoostTestVersion == null) ? string.Empty : TestRunnerFactoryOptions.ForcedBoostTestVersion.ToString();
+            }
+
+            set
+            {
+                TestRunnerFactoryOptions.ForcedBoostTestVersion = (string.IsNullOrEmpty(value) ? null : Version.Parse(value));
+            }
+        }
 
         #endregion Serialisable Fields
 

--- a/BoostTestAdapter/Settings/ExternalBoostTestRunnerSettings.cs
+++ b/BoostTestAdapter/Settings/ExternalBoostTestRunnerSettings.cs
@@ -25,7 +25,7 @@ namespace BoostTestAdapter.Settings
     /// Identifies the external test runner configuration block and its configuration options.
     /// </summary>
     [XmlRoot(Xml.ExternalTestRunner)]
-    public class ExternalBoostTestRunnerSettings : IXmlSerializable
+    public class ExternalBoostTestRunnerSettings : IXmlSerializable, IEquatable<ExternalBoostTestRunnerSettings>
     {
         #region Constants
 
@@ -112,5 +112,36 @@ namespace BoostTestAdapter.Settings
 
         #endregion IXmlSerializable
 
+        #region Object
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ExternalBoostTestRunnerSettings);
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = 17;
+
+            hash = hash * 33 + ((ExtensionType == null) ? 0 : ExtensionType.ToString().GetHashCode());
+            hash = hash * 33 + DiscoveryMethodType.GetHashCode();
+            hash = hash * 33 + ((ExecutionCommandLine == null) ? 0 : ExecutionCommandLine.ToString().GetHashCode());
+
+            return hash;
+        }
+
+        #endregion
+
+        #region IEquatable<ExternalBoostTestRunnerSettings>
+
+        public bool Equals(ExternalBoostTestRunnerSettings other)
+        {
+            return (other != null) &&
+                ((ExtensionType == other.ExtensionType) || ((ExtensionType != null) && (ExtensionType.ToString() == other.ExtensionType.ToString()))) &&
+                (DiscoveryMethodType == other.DiscoveryMethodType) &&
+                ((ExecutionCommandLine == other.ExecutionCommandLine) || ((ExecutionCommandLine != null) && (ExecutionCommandLine.ToString() == other.ExecutionCommandLine.ToString())));
+        }
+
+        #endregion
     }
 }

--- a/BoostTestAdapter/Utility/ByteArrayUtils.cs
+++ b/BoostTestAdapter/Utility/ByteArrayUtils.cs
@@ -1,0 +1,169 @@
+﻿// https://github.com/csoltenborn/GoogleTestAdapter
+
+using System;
+using System.Text;
+
+namespace BoostTestAdapter.Utility
+{
+    /// <summary>
+    /// Byte-pattern utilities which allow fast lookup/search
+    /// </summary>
+    public static class ByteUtilities
+    {
+        /// <summary>
+        /// Representation of a Boyer-Moore 'byte' search pattern (needle)
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")]
+        public class BoyerMooreBytePattern
+        {
+            #region Members
+
+            private int[] byteBasedJumpTable;
+            private int[] offsetBasedJumpTable;
+            private readonly byte[] _pattern = null;
+
+            #endregion
+
+            #region Constructors
+
+            public BoyerMooreBytePattern(string pattern, Encoding encoding)
+                : this(encoding?.GetBytes(pattern))
+            {
+            }
+
+            public BoyerMooreBytePattern(byte[] pattern)
+            {
+                this._pattern = pattern;
+
+                this.byteBasedJumpTable = CreateByteBasedJumpTable(pattern);
+                this.offsetBasedJumpTable = CreateOffsetBasedJumpTable(pattern);
+            }
+
+            #endregion
+
+            public byte[] GetPattern()
+            {
+                return _pattern;
+            }
+
+            public int CalculateJumpOffset(int offset, byte value)
+            {
+                int jumpOffset = Math.Max(GetPattern().Length - 1 - offset, 0);
+                return Math.Max(offsetBasedJumpTable[jumpOffset], byteBasedJumpTable[value]);
+            }
+
+            private static int[] CreateByteBasedJumpTable(byte[] pattern)
+            {
+                int[] table = new int[byte.MaxValue + 1];
+
+                for (int i = 0; i < table.Length; ++i)
+                {
+                    table[i] = pattern.Length;
+                }
+
+                if (pattern.Length > 0)
+                {
+                    for (int i = 0; i < pattern.Length - 1; ++i)
+                    {
+                        table[pattern[i]] = pattern.Length - 1 - i;
+                    }
+                }
+
+                return table;
+            }
+
+            private static int[] CreateOffsetBasedJumpTable(byte[] pattern)
+            {
+                int[] table = new int[Math.Max(pattern.Length, 1)];
+
+                int lastPrefixPosition = pattern.Length;
+
+                for (int i = pattern.Length; i > 0; i--)
+                {
+                    if (IsPrefix(pattern, i))
+                    {
+                        lastPrefixPosition = i;
+                    }
+
+                    table[pattern.Length - i] = lastPrefixPosition - i + pattern.Length;
+                }
+
+                for (int i = 0; i < pattern.Length - 1; i++)
+                {
+                    int suffixLength = GetSuffixLength(pattern, i);
+                    table[suffixLength] = pattern.Length - 1 - i + suffixLength;
+                }
+
+                return table;
+            }
+
+            private static bool IsPrefix(byte[] pattern, int position)
+            {
+                for (int i = position, j = 0; i < pattern.Length; i++, j++)
+                {
+                    if (pattern[i] != pattern[j])
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            private static int GetSuffixLength(byte[] pattern, int position)
+            {
+                int length = 0;
+
+                for (int i = position, j = (pattern.Length - 1); (i >= 0) && (pattern[i] == pattern[j]); i--, j--)
+                {
+                    length++;
+                }
+
+                return length;
+            }
+        }
+
+        /// <summary>
+        /// Implementation of the Boyer-Moore algorithm 
+        /// (after https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string_search_algorithm, Java version)
+        /// </summary>
+        /// <param name="value">The haystack in which to search the pattern of interest</param>
+        /// <param name="pattern">The needle to search for</param>
+        /// <returns>Index of the first occurence of <code>pattern</code>, or <code>-1</code> if <code>pattern</code> is not contained in <code>bytes</code></returns>
+        public static int IndexOf(this byte[] value, byte[] pattern)
+        {
+            return IndexOf(value, new BoyerMooreBytePattern(pattern));
+        }
+
+        /// <summary>
+        /// Implementation of the Boyer-Moore algorithm 
+        /// (after https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string_search_algorithm, Java version)
+        /// </summary>
+        /// <param name="value">The haystack in which to search the pattern of interest</param>
+        /// <param name="pattern">The needle to search for</param>
+        /// <returns>Index of the first occurence of <code>pattern</code>, or <code>-1</code> if <code>pattern</code> is not contained in <code>bytes</code></returns>
+        public static int IndexOf(this byte[] value, BoyerMooreBytePattern pattern)
+        {
+            if ((pattern == null) || (pattern.GetPattern().Length == 0))
+            {
+                return 0;
+            }
+
+            for (int posInBytes = (pattern.GetPattern().Length - 1); posInBytes < value.Length;)
+            {
+                int posInPattern;
+                for (posInPattern = (pattern.GetPattern().Length - 1); pattern.GetPattern()[posInPattern] == value[posInBytes]; --posInBytes, --posInPattern)
+                {
+                    if (posInPattern == 0)
+                    {
+                        return posInBytes;
+                    }
+                }
+
+                posInBytes += pattern.CalculateJumpOffset(posInPattern, value[posInBytes]);
+            }
+
+            return -1;
+        }
+    }
+}

--- a/BoostTestAdapter/Utility/DebugHelperNative.cs
+++ b/BoostTestAdapter/Utility/DebugHelperNative.cs
@@ -87,7 +87,7 @@ namespace BoostTestAdapter.Utility
                 public fixed byte OptionalHeader[224];
             }
 
-            [StructLayout(LayoutKind.Sequential)]
+            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
             internal struct SYMBOL_INFO
             {
                 public uint SizeOfStruct;

--- a/BoostTestAdapter/Utility/DebugHelperNative.cs
+++ b/BoostTestAdapter/Utility/DebugHelperNative.cs
@@ -5,6 +5,8 @@
 
 using Microsoft.Win32.SafeHandles;
 using System;
+using System.Linq;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -227,10 +229,12 @@ namespace BoostTestAdapter.Utility
             [DllImport("DbgHelp.dll", SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
             public extern static bool SymUnloadModule64(IntPtr hProcess, ulong baseOfDll);
+            
+            public delegate bool SymEnumSymbolsProc(ref SYMBOL_INFO symInfo, uint symbolSize, IntPtr contextZero);
 
             [DllImport("DbgHelp.dll", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public extern static bool SymFromName(IntPtr hProcess, string SymName, ref SYMBOL_INFO symInfo);
+            public extern static bool SymEnumSymbols(IntPtr hProcess, ulong baseOfDll, string mask, SymEnumSymbolsProc callback, IntPtr contextZero);
 
             [DllImport("DbgHelp.dll")]
             public static extern unsafe void* ImageDirectoryEntryToData(IntPtr pBase, byte mappedAsImage, ushort directoryEntry, uint* size);
@@ -280,7 +284,10 @@ namespace BoostTestAdapter.Utility
 
             if (_dllBase == 0)
             {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
+                int error = Marshal.GetLastWin32Error();
+                Dispose(false);
+
+                throw new Win32Exception(error);
             }
 
             _libHandle = handle;
@@ -442,12 +449,20 @@ namespace BoostTestAdapter.Utility
         private void Dispose(bool disposing)
         {
             if (_disposed)
+            { 
                 return;
+            }
 
             if (_libHandle == IntPtr.Zero)
+            { 
                 return;
+            }
 
-            NativeMethods.SymUnloadModule64(_libHandle, _dllBase);
+            if (_dllBase != 0)
+            { 
+                NativeMethods.SymUnloadModule64(_libHandle, _dllBase);
+            }
+
             NativeMethods.SymCleanup(_libHandle);
 
             _libHandle = IntPtr.Zero;
@@ -464,18 +479,24 @@ namespace BoostTestAdapter.Utility
         #endregion IDisposable
 
         /// <summary>
-        /// Determines whether or not a symbol with the <b>exact</b> provided name is available.
+        /// Performs a symbol lookup via a wildcard pattern and enumerates the fully-qualified name of
+        /// the symbols in question
         /// </summary>
-        /// <param name="name">The name of the symbol to search for.</param>
-        /// <returns>true if the symbol is available; false otherwise.</returns>
-        public bool ContainsSymbol(string name)
+        /// <param name="mask">The wildcard symbol name pattern</param>
+        /// <returns>A collection of symbols which match the provided wildcard pattern</returns>
+        public IEnumerable<string> LookupSymbolNamesByPattern(string mask)
         {
-            Code.Require(name, "name");
+            var symbols = new List<string>();
 
-            LastErrorMessage = string.Empty;
+            NativeMethods.SymEnumSymbolsProc callback = (ref NativeMethods.SYMBOL_INFO symInfo, uint symbolSize, IntPtr context) =>
+            {
+                symbols.Add(symInfo.Name);
+                return true;
+            };
             
-            NativeMethods.SYMBOL_INFO symbol = new NativeMethods.SYMBOL_INFO();
-            return NativeMethods.SymFromName(_libHandle, name, ref symbol);
+            var result = NativeMethods.SymEnumSymbols(_libHandle, _dllBase, mask, callback, IntPtr.Zero);
+
+            return (result) ? symbols : Enumerable.Empty<string>();
         }
     }
 }

--- a/BoostTestAdapter/Utility/Logger.cs
+++ b/BoostTestAdapter/Utility/Logger.cs
@@ -4,6 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 using System;
+using System.Threading;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -45,6 +46,7 @@ namespace BoostTestAdapter.Utility
             string configFilePath = Path.Combine(pathOfExecutingAssembly, (assemblyName + ".dll.config"));
 
             log4net.GlobalContext.Properties["pid"] = Process.GetCurrentProcess().Id;
+            log4net.GlobalContext.Properties["threadid"] = Thread.CurrentThread.ManagedThreadId;
             log4net.GlobalContext.Properties["LogFilePath"] = logFilePath;
             log4net.Config.XmlConfigurator.Configure(new FileInfo(configFilePath));
         }

--- a/BoostTestAdapter/Utility/TimedScope.cs
+++ b/BoostTestAdapter/Utility/TimedScope.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace BoostTestAdapter.Utility
+{
+    /// <summary>
+    /// RAII class which logs the time taken until
+    /// disposed
+    /// </summary>
+    /// <remarks>Ideal for use with a 'using' scope</remarks>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1063:ImplementIDisposableCorrectly", Justification = "Debug utility mimicking RAII")]
+    public class TimedScope : IDisposable
+    {
+        /// <summary>
+        /// Constructor which identifies a time scope via a string ID
+        /// </summary>
+        /// <param name="format">Format string for scope ID</param>
+        /// <param name="args">Format arguments for format string</param>
+        public TimedScope(string format, params object[] args)
+        {
+            ScopeId = string.Format(CultureInfo.InvariantCulture, format, args);
+
+            Watch = new Stopwatch();
+            Watch.Start();
+        }
+
+        /// <summary>
+        /// Timed Scope ID
+        /// </summary>
+        public string ScopeId { get; private set; }
+
+        /// <summary>
+        /// Timed Scope StopWatch
+        /// </summary>
+        private Stopwatch Watch { get; set; }
+
+        #region IDisposable
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1063:ImplementIDisposableCorrectly", Justification = "Debug utility mimicking RAII")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1816:CallGCSuppressFinalizeCorrectly", Justification = "Debug utility mimicking RAII")]
+        public void Dispose()
+        {
+            var elapsed = Watch.ElapsedMilliseconds;
+            Watch.Stop();
+
+            Logger.Debug("Duration of \"{0}\": {1}ms", ScopeId, elapsed);
+        }
+
+        #endregion
+    }
+}

--- a/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
+++ b/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
@@ -48,12 +48,25 @@ namespace BoostTestAdapter.Utility.VisualStudio
             }
         }
 
+        private static readonly TestProperty _version = TestProperty.Register("Boost.Test.Boost.Version", "Boost Version", typeof(string), typeof(VSTestModel));
+
+        /// <summary>
+        /// Boost.Test Boost Version property
+        /// </summary>
+        public static TestProperty VersionProperty
+        {
+            get
+            {
+                return _version;
+            }
+        }
+        
         /// <summary>
         /// Converts forward slashes in a file path to backward slashes.
         /// </summary>
         /// <param name="path_in"> The input path</param>
         /// <returns>The output path, modified with backward slashes </returns>
-       
+
         private static string ConvertSlashes(string path_in)
         {
             return path_in.Replace('/', '\\');

--- a/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
+++ b/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
@@ -48,19 +48,11 @@ namespace BoostTestAdapter.Utility.VisualStudio
             }
         }
 
-        private static readonly TestProperty _version = TestProperty.Register("Boost.Test.Boost.Version", "Boost Version", typeof(string), typeof(VSTestModel));
-
         /// <summary>
         /// Boost.Test Boost Version property
         /// </summary>
-        public static TestProperty VersionProperty
-        {
-            get
-            {
-                return _version;
-            }
-        }
-        
+        public static TestProperty VersionProperty { get; } = TestProperty.Register("Boost.Test.Boost.Version", "Boost Version", typeof(string), typeof(VSTestModel));
+
         /// <summary>
         /// Converts forward slashes in a file path to backward slashes.
         /// </summary>

--- a/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
+++ b/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
@@ -42,6 +42,7 @@
     <Compile Include="BoostTestRunnerCommandLineArgsTest.cs" />
     <Compile Include="BoostTestSettingsTest.cs" />
     <Compile Include="BoostTestTest.cs" />
+    <Compile Include="CachingBoostTestRunnerFactoryTest.cs" />
     <Compile Include="CommandEvaluatorTest.cs" />
     <Compile Include="CorrectReferencedAssembliesTest.cs" />
     <Compile Include="DefaultBoostTestRunnerFactoryTest.cs" />

--- a/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
+++ b/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
@@ -103,6 +103,7 @@
     <EmbeddedResource Include="Resources\ListContentDOT\test_list_content.gv" />
     <EmbeddedResource Include="Resources\ListContentDOT\boost_data_test_case.gv" />
     <EmbeddedResource Include="Resources\ListContentDOT\special_characters.list.content.gv" />
+    <EmbeddedResource Include="Resources\Version\sample.version.stderr.log" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\ReportsLogs\AbortedTest\sample.test.log.xml" />

--- a/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
+++ b/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
@@ -42,6 +42,7 @@
     <Compile Include="BoostTestRunnerCommandLineArgsTest.cs" />
     <Compile Include="BoostTestSettingsTest.cs" />
     <Compile Include="BoostTestTest.cs" />
+    <Compile Include="ByteUtilsTests.cs" />
     <Compile Include="CachingBoostTestRunnerFactoryTest.cs" />
     <Compile Include="CommandEvaluatorTest.cs" />
     <Compile Include="CorrectReferencedAssembliesTest.cs" />

--- a/BoostTestAdapterNunit/BoostTestDiscovererFactoryTest.cs
+++ b/BoostTestAdapterNunit/BoostTestDiscovererFactoryTest.cs
@@ -13,6 +13,7 @@ using BoostTestAdapter.Settings;
 using BoostTestAdapter.Boost.Runner;
 
 using BoostTestAdapterNunit.Fakes;
+using BoostTestAdapterNunit.Utility;
 
 using NUnit.Framework;
 using FakeItEasy;
@@ -28,7 +29,7 @@ namespace BoostTestAdapterNunit
         public void SetUp()
         {
             this.RunnerFactory = new StubBoostTestRunnerFactory(new[] { ("ListContentSupport" + BoostTestDiscoverer.ExeExtension) });
-            this.DiscovererFactory = new BoostTestDiscovererFactory(this.RunnerFactory);
+            this.DiscovererFactory = new BoostTestDiscovererFactory(this.RunnerFactory, DummyBoostTestPackageServiceFactory.Default);
         }
 
         #endregion Test Setup/Teardown
@@ -115,8 +116,7 @@ namespace BoostTestAdapterNunit
             Assert.That(exd.Sources, Is.EqualTo(new[] { "DllProject1" + BoostTestDiscoverer.DllExtension,
                 "DllProject2" + BoostTestDiscoverer.DllExtension }));
         }
-
-
+        
         /// <summary>
         /// The aim of this test is to check that if the Discoverer is given multiple projects,
         /// the factory dispatches the discoverers accordingly to the type of source.
@@ -179,10 +179,8 @@ namespace BoostTestAdapterNunit
             discoverer = this.DiscovererFactory.GetDiscoverer(source, settings);
 
             Assert.That(discoverer, Is.Null);
-
         }
-
-
+        
         /// <summary>
         /// The aim of this test is to check that if the Discoverer is given a single project,
         /// the factory returns the discoverer accordingly to the type of source.

--- a/BoostTestAdapterNunit/BoostTestDiscovererTest.cs
+++ b/BoostTestAdapterNunit/BoostTestDiscovererTest.cs
@@ -184,13 +184,9 @@ namespace BoostTestAdapterNunit
             this.Source = source;
         }
 
-        public bool ListContentSupported
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public bool ListContentSupported { get; } = true;
+
+        public bool VersionSupported { get; } = false;
 
         public string Source { get; private set; }
 

--- a/BoostTestAdapterNunit/BoostTestDiscovererTest.cs
+++ b/BoostTestAdapterNunit/BoostTestDiscovererTest.cs
@@ -18,6 +18,7 @@ using NUnit.Framework;
 using BoostTestAdapter.Boost.Runner;
 using FakeItEasy;
 using BoostTestAdapter.Utility.ExecutionContext;
+using System;
 
 namespace BoostTestAdapterNunit
 {
@@ -184,10 +185,8 @@ namespace BoostTestAdapterNunit
             this.Source = source;
         }
 
-        public bool ListContentSupported { get; } = true;
-
-        public bool VersionSupported { get; } = false;
-
+        public IBoostTestRunnerCapabilities Capabilities { get; } = new BoostTestRunnerCapabilities { ListContent = true, Version = false };
+        
         public string Source { get; private set; }
 
         public int Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext context)

--- a/BoostTestAdapterNunit/BoostTestExecutorTest.cs
+++ b/BoostTestAdapterNunit/BoostTestExecutorTest.cs
@@ -274,8 +274,6 @@ namespace BoostTestAdapterNunit
                 base(parent)
             {
                 this.Source = source;
-                this.ListContentSupported = false;
-
                 this.ExecutionArgs = new List<MockBoostTestRunnerExecutionArgs>();
             }
 
@@ -344,9 +342,7 @@ namespace BoostTestAdapterNunit
 
             public string Source { get; private set; }
 
-            public bool ListContentSupported { get; private set; }
-
-            public bool VersionSupported { get; } = false;
+            public IBoostTestRunnerCapabilities Capabilities { get; } = new BoostTestRunnerCapabilities { ListContent = false, Version = false };
 
             #endregion IBoostTestRunner
 

--- a/BoostTestAdapterNunit/BoostTestExecutorTest.cs
+++ b/BoostTestAdapterNunit/BoostTestExecutorTest.cs
@@ -346,8 +346,9 @@ namespace BoostTestAdapterNunit
 
             public bool ListContentSupported { get; private set; }
 
-            #endregion IBoostTestRunner
+            public bool VersionSupported { get; } = false;
 
+            #endregion IBoostTestRunner
 
             private void Copy(string embeddedResource, string path)
             {

--- a/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
@@ -142,6 +142,8 @@ namespace BoostTestAdapterNunit
             Assert.That(args.DetectFPExceptions, Is.EqualTo(clone.DetectFPExceptions));
             Assert.That(args.SavePattern, Is.EqualTo(clone.SavePattern));
             Assert.That(args.ListContent, Is.EqualTo(clone.ListContent));
+            Assert.That(args.Help, Is.EqualTo(clone.Help));
+            Assert.That(args.Version, Is.EqualTo(clone.Version));
 
             Assert.That(args.ToString(), Is.EqualTo(clone.ToString()));
         }
@@ -194,6 +196,33 @@ namespace BoostTestAdapterNunit
             
             // list content only includes the --list_content and the output redirection commands
             Assert.That(args.ToString(), Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// Assert that: A Boost.Test command-line requiring version output is generated accordingly
+        /// </summary>
+        [Test]
+        public void VersionCommandLineArgs()
+        {
+            BoostTestRunnerCommandLineArgs args = new BoostTestRunnerCommandLineArgs()
+            {
+                Version = true
+            };
+
+            // Version without output redirection
+            {
+                const string expected = "\"--version\"";
+                Assert.That(args.ToString(), Is.EqualTo(expected));
+            }
+
+            // Version with output redirection
+            {
+                args.StandardOutFile = @"C:\Temp\version.out";
+                args.StandardErrorFile = @"C:\Temp\version.err";
+
+                const string expected = "\"--version\" > \"C:\\Temp\\version.out\" 2> \"C:\\Temp\\version.err\"";
+                Assert.That(args.ToString(), Is.EqualTo(expected));
+            }
         }
 
         #endregion Tests

--- a/BoostTestAdapterNunit/BoostTestSettingsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSettingsTest.cs
@@ -64,7 +64,7 @@ namespace BoostTestAdapterNunit
             Assert.That(settings.DetectFloatingPointExceptions, Is.False);
             Assert.That(settings.CatchSystemErrors, Is.True);
             Assert.That(settings.TestBatchStrategy, Is.EqualTo(Strategy.TestCase));
-            Assert.That(settings.ForceListContent, Is.False);
+            Assert.That(settings.ForceBoostVersion, Is.Empty);
             Assert.That(settings.WorkingDirectory, Is.Null);
             Assert.That(settings.EnableStdOutRedirection, Is.True);
             Assert.That(settings.EnableStdErrRedirection, Is.True);
@@ -193,6 +193,18 @@ namespace BoostTestAdapterNunit
         {
             BoostTestAdapterSettings settings = ParseXml(settingsXml);
             return settings.PostTestDelay;
+        }
+
+        /// <summary>
+        /// Assert that: The 'ForceBoostVersion' option can be properly parsed
+        /// </summary>
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><ForceBoostVersion>1.59</ForceBoostVersion></BoostTest></RunSettings>", Result = "1.59")]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><ForceBoostVersion>1.62</ForceBoostVersion></BoostTest></RunSettings>", Result = "1.62")]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><ForceBoostVersion>1.63</ForceBoostVersion></BoostTest></RunSettings>", Result = "1.63")]
+        public string ParseForceBoostVersion(string settingsXml)
+        {
+            BoostTestAdapterSettings settings = ParseXml(settingsXml);
+            return settings.ForceBoostVersion;
         }
 
         #endregion Tests

--- a/BoostTestAdapterNunit/ByteUtilsTests.cs
+++ b/BoostTestAdapterNunit/ByteUtilsTests.cs
@@ -1,0 +1,85 @@
+﻿// https://github.com/csoltenborn/GoogleTestAdapter
+
+using System.Text;
+
+using BoostTestAdapter.Utility;
+
+using NUnit.Framework;
+
+namespace BoostTestAdapterNunit
+{
+    [TestFixture]
+    public class ByteUtilsTests
+    {
+        [Test]
+        public void IndexOf_FooEmptyPattern_ReturnsFound()
+        {
+            var bytes = Encoding.ASCII.GetBytes("foo");
+            var pattern = Encoding.ASCII.GetBytes("");
+            var index = bytes.IndexOf(pattern);
+
+            Assert.That(index, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void IndexOf_EmptyBytesFoo_ReturnsNotFound()
+        {
+            var bytes = Encoding.ASCII.GetBytes("");
+            var pattern = Encoding.ASCII.GetBytes("foo");
+            var index = bytes.IndexOf(pattern);
+
+            Assert.That(index, Is.EqualTo(-1));
+        }
+
+        [Test]
+        public void IndexOf_EmptyBytesEmptyPattern_ReturnsFound()
+        {
+            var bytes = Encoding.ASCII.GetBytes("");
+            var pattern = Encoding.ASCII.GetBytes("");
+            var index = bytes.IndexOf(pattern);
+
+            Assert.That(index, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void IndexOf_FooBar_ReturnsNotFound()
+        {
+            var bytes = Encoding.ASCII.GetBytes("foofoofoo");
+            var pattern = Encoding.ASCII.GetBytes("bar");
+            var index = bytes.IndexOf(pattern);
+
+            Assert.That(index, Is.EqualTo(-1));
+        }
+
+        [Test]
+        public void IndexOf_FooAtBeginning_ReturnsFound()
+        {
+            var bytes = Encoding.ASCII.GetBytes("fooxxx");
+            var pattern = Encoding.ASCII.GetBytes("foo");
+            var index = bytes.IndexOf(pattern);
+
+            Assert.That(index, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void IndexOf_FooAtEnd_ReturnsFound()
+        {
+            var bytes = Encoding.ASCII.GetBytes("xxxfoo");
+            var pattern = Encoding.ASCII.GetBytes("foo");
+            var index = bytes.IndexOf(pattern);
+
+            Assert.That(index, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void IndexOf_FooInMiddle_ReturnsFound()
+        {
+            var bytes = Encoding.ASCII.GetBytes("xxxfooxxx");
+            var pattern = Encoding.ASCII.GetBytes("foo");
+            var index = bytes.IndexOf(pattern);
+
+            Assert.That(index, Is.EqualTo(3));
+        }
+
+    }
+}

--- a/BoostTestAdapterNunit/CachingBoostTestRunnerFactoryTest.cs
+++ b/BoostTestAdapterNunit/CachingBoostTestRunnerFactoryTest.cs
@@ -1,0 +1,92 @@
+﻿// (C) Copyright 2015 ETAS GmbH (http://www.etas.com/)
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+using System.Linq;
+
+using BoostTestAdapter.Boost.Runner;
+
+using FakeItEasy;
+using NUnit.Framework;
+
+namespace BoostTestAdapterNunit
+{
+    [TestFixture]
+    public class CachingBoostTestRunnerFactoryTest
+    {
+        #region Test Setup/Teardown
+
+        [SetUp]
+        public void SetUp()
+        {
+            var stub = A.Fake<IBoostTestRunnerFactory>();
+
+            A.CallTo(() => stub.GetRunner(A<string>._, A<BoostTestRunnerFactoryOptions>._)).ReturnsLazily((string identifier, BoostTestRunnerFactoryOptions options) =>
+            {
+                var runner = A.Fake<IBoostTestRunner>();
+                A.CallTo(() => runner.Source).Returns(identifier);
+
+                return runner;
+            });
+
+            Factory = new CachingBoostTestRunnerFactory(stub);
+        }
+
+        #endregion Test Setup/Teardown
+        
+        #region Test Data
+
+        private CachingBoostTestRunnerFactory Factory { get; set; }
+        
+        #endregion Test Data
+
+        #region Tests
+        
+        /// <summary>
+        /// Assert that: Runners are cached as long as the factory options and the identifier are equivalent
+        /// </summary>
+        [Test]
+        public void CacheRunnersBasedOnIdentifier()
+        {
+            var runner = Factory.GetRunner("hello", null);
+            Assert.That(runner, Is.Not.Null);
+
+            var runner2 = Factory.GetRunner("hello", null);
+            Assert.That(runner2, Is.EqualTo(runner));
+            
+            var runner3 = Factory.GetRunner("not-hello", null);
+            Assert.That(runner3, Is.Not.Null);
+            Assert.That(runner3, Is.Not.EqualTo(runner2));
+        }
+
+        /// <summary>
+        /// Assert that: Runners are cached as long as the factory options and the identifier are equivalent
+        /// </summary>
+        [Test]
+        public void CacheRunnersBasedOnBoostVersion()
+        {
+            BoostTestRunnerFactoryOptions options = new BoostTestRunnerFactoryOptions
+            {
+                ForcedBoostTestVersion = DefaultBoostTestRunnerFactory.Boost159
+            };
+
+            var runner = Factory.GetRunner("hello", options);
+            Assert.That(runner, Is.Not.Null);
+
+            var runner2 = Factory.GetRunner("hello", options);
+            Assert.That(runner2, Is.EqualTo(runner));
+
+            var runner3 = Factory.GetRunner("not-hello", options);
+            Assert.That(runner3, Is.Not.Null);
+            Assert.That(runner3, Is.Not.EqualTo(runner2));
+            
+            var runner4 = Factory.GetRunner("hello", new BoostTestRunnerFactoryOptions());
+            Assert.That(runner4, Is.Not.Null);
+            Assert.That(runner4, Is.Not.EqualTo(runner2));
+            Assert.That(runner4, Is.Not.EqualTo(runner3));
+        }
+        
+        #endregion
+    }
+}

--- a/BoostTestAdapterNunit/DOTDeserialisationTest.cs
+++ b/BoostTestAdapterNunit/DOTDeserialisationTest.cs
@@ -56,13 +56,26 @@ namespace BoostTestAdapterNunit
         /// <param name="encoding">The encoding by which to interpret the resource file</param>
         private void Compare(string resource, TestFramework expected, Encoding encoding)
         {
-            using (var stream = TestHelper.LoadEmbeddedResource(resource))
-            using (var reader = new StreamReader(stream, encoding))
+            Stream stream = null;
+            try
             {
-                TestFrameworkDOTDeserialiser parser = new TestFrameworkDOTDeserialiser(Source);
-                TestFramework framework = parser.Deserialise(reader);
+                stream = TestHelper.LoadEmbeddedResource(resource);
+                using (var reader = new StreamReader(stream, encoding))
+                {
+                    stream = null;
 
-                FrameworkEqualityVisitor.IsEqualTo(framework, expected, false);
+                    TestFrameworkDOTDeserialiser parser = new TestFrameworkDOTDeserialiser(Source);
+                    TestFramework framework = parser.Deserialise(reader);
+
+                    FrameworkEqualityVisitor.IsEqualTo(framework, expected, false);
+                }
+            }
+            finally
+            {
+                if (stream != null)
+                {
+                    stream.Dispose();
+                }
             }
         }
 

--- a/BoostTestAdapterNunit/DefaultBoostTestRunnerFactoryTest.cs
+++ b/BoostTestAdapterNunit/DefaultBoostTestRunnerFactoryTest.cs
@@ -30,30 +30,93 @@ namespace BoostTestAdapterNunit
         private DefaultBoostTestRunnerFactory Factory { get; set; }
 
         #endregion Test Data
-
-        #region Tests
         
+        #region Tests
+
         /// <summary>
         /// Provisions internal and external IBoostTestRunner instances based on the requested source and settings.
         /// 
         /// Test aims:
         ///     - Ensure that the proper IBoostTestRunner type is provided for the requested source.
         /// </summary>
-        // Exe types
-        [TestCase("test.exe", null, typeof(BoostTestRunner))]
-        [TestCase("test.exe", ".dll", typeof(BoostTestRunner))]
-        [TestCase("test.exe", ".exe", typeof(ExternalBoostTestRunner))]
-        // Dll types
-        [TestCase("test.dll", null, null)]
-        [TestCase("test.dll", ".dll", typeof(ExternalBoostTestRunner))]
-        [TestCase("test.dll", ".exe", null)]
-        // Invalid extension types
-        [TestCase("test.txt", null, null)]
-        [TestCase("test.txt", ".dll", null)]
-        [TestCase("test.txt", ".exe", null)]
-        public void ExternalBoostTestRunnerProvisioning(string source, string externalExtension, Type type)
+        // EXE types
+        [TestCase("test.exe", null, null, Result = typeof(BoostTestRunner))]
+        [TestCase("test.exe", "1.59", null, Result = typeof(BoostTestRunnerCapabilityOverride))]
+        [TestCase("test.exe", "1.62", null, Result = typeof(BoostTestRunnerCapabilityOverride))]
+        [TestCase("test.exe", "1.63", null, Result = typeof(BoostTestRunnerCapabilityOverride))]
+
+        [TestCase("test.exe", null, ".dll", Result = typeof(BoostTestRunner))]
+        [TestCase("test.exe", "1.59", ".dll", Result = typeof(BoostTestRunnerCapabilityOverride))]
+        [TestCase("test.exe", "1.62", ".dll", Result = typeof(BoostTestRunnerCapabilityOverride))]
+        [TestCase("test.exe", "1.63", ".dll", Result = typeof(BoostTestRunnerCapabilityOverride))]
+
+        [TestCase("test.exe", null, ".exe", Result = typeof(ExternalBoostTestRunner))]
+        [TestCase("test.exe", "1.59", ".exe", Result = typeof(BoostTestRunnerCapabilityOverride))]
+        [TestCase("test.exe", "1.62", ".exe", Result = typeof(BoostTestRunnerCapabilityOverride))]
+        [TestCase("test.exe", "1.63", ".exe", Result = typeof(BoostTestRunnerCapabilityOverride))]
+        
+        // EXE types - .test.boostd.exe
+        [TestCase("test.test.boostd.exe", null, null, Result = typeof(BoostTestRunnerCapabilityOverride))]
+
+        // EXE types - .test.boostd.exe (case-insensitive)
+        [TestCase("test.TEST.BOOSTD.exe", null, null, Result = typeof(BoostTestRunnerCapabilityOverride))]
+
+        // EXE types - .test.boost.exe
+        [TestCase("test.test.boost.exe", null, null, Result = typeof(BoostTestRunnerCapabilityOverride))]
+
+        // .EXE types - test.boostd.exe (case-insensitive)
+        [TestCase("test.TEST.BOOST.exe", null, null, Result = typeof(BoostTestRunnerCapabilityOverride))]
+
+        // EXE types - .AcceptanceTest.boostd.exe
+        [TestCase("test.AcceptanceTest.boostd.exe", null, null, Result = typeof(BoostTestRunnerCapabilityOverride))]
+
+        // EXE types - .Acceptancetest.boostd.exe (case-insensitive)
+        [TestCase("test.Acceptancetest.boostd.exe", null, null, Result = typeof(BoostTestRunnerCapabilityOverride))]
+
+        // EXE types - .AcceptanceTest.boost.exe
+        [TestCase("test.AcceptanceTest.boost.exe", null, null, Result = typeof(BoostTestRunnerCapabilityOverride))]
+
+        // EXE types - .Acceptancetest.boost.exe (case-insensitive)
+        [TestCase("test.Acceptancetest.boost.exe", null, null, Result = typeof(BoostTestRunnerCapabilityOverride))]
+        
+        // DLL types 
+        [TestCase("test.dll", null, null, Result = null)]
+        [TestCase("test.dll", "1.59", null, Result = null)]
+        [TestCase("test.dll", "1.62", null, Result = null)]
+        [TestCase("test.dll", "1.63", null, Result = null)]
+
+        [TestCase("test.dll", null, ".dll", Result = typeof(ExternalBoostTestRunner))]
+        [TestCase("test.dll", "1.59", ".dll", Result = typeof(BoostTestRunnerCapabilityOverride))]
+        [TestCase("test.dll", "1.62", ".dll", Result = typeof(BoostTestRunnerCapabilityOverride))]
+        [TestCase("test.dll", "1.63", ".dll", Result = typeof(BoostTestRunnerCapabilityOverride))]
+
+        [TestCase("test.dll", null, ".exe", Result = null)]
+        [TestCase("test.dll", "1.59", ".exe", Result = null)]
+        [TestCase("test.dll", "1.62", ".exe", Result = null)]
+        [TestCase("test.dll", "1.63", ".exe", Result = null)]
+
+        // Invalid extension
+        [TestCase("test.txt", null, null, Result = null)]
+        [TestCase("test.txt", "1.59", null, Result = null)]
+        [TestCase("test.txt", "1.62", null, Result = null)]
+        [TestCase("test.txt", "1.63", null, Result = null)]
+
+        [TestCase("test.txt", null, ".dll", Result = null)]
+        [TestCase("test.txt", "1.59", ".dll", Result = null)]
+        [TestCase("test.txt", "1.62", ".dll", Result = null)]
+        [TestCase("test.txt", "1.63", ".dll", Result = null)]
+
+        [TestCase("test.txt", null, ".exe", Result = null)]
+        [TestCase("test.txt", "1.59", ".exe", Result = null)]
+        [TestCase("test.txt", "1.62", ".exe", Result = null)]
+        [TestCase("test.txt", "1.63", ".exe", Result = null)]
+        public Type ExternalBoostTestRunnerProvisioning(string source, string boostTestVersion, string externalExtension)
         {
-            BoostTestRunnerFactoryOptions options = new BoostTestRunnerFactoryOptions();
+            var options = new BoostTestRunnerFactoryOptions()
+            {
+                ForcedBoostTestVersion = (string.IsNullOrEmpty(boostTestVersion)) ? null : Version.Parse(boostTestVersion)
+            };
+
             if (externalExtension != null)
             {
                 options.ExternalTestRunnerSettings = new ExternalBoostTestRunnerSettings
@@ -63,16 +126,9 @@ namespace BoostTestAdapterNunit
                 };
             }
             
-            IBoostTestRunner runner = this.Factory.GetRunner(source, options);
+            var runner = Factory.GetRunner(source, options);
 
-            if (runner == null)
-            {
-                Assert.That(type, Is.Null);
-            }
-            else
-            {
-                Assert.That(runner, Is.AssignableTo(type));
-            }
+            return runner?.GetType();
         }
 
         #endregion Tests

--- a/BoostTestAdapterNunit/DefaultTestDiscovererFactoryTest.cs
+++ b/BoostTestAdapterNunit/DefaultTestDiscovererFactoryTest.cs
@@ -13,6 +13,7 @@ using BoostTestAdapter.Discoverers;
 using BoostTestAdapter.Boost.Runner;
 
 using BoostTestAdapterNunit.Fakes;
+using BoostTestAdapterNunit.Utility;
 
 using NUnit.Framework;
 
@@ -27,7 +28,7 @@ namespace BoostTestAdapterNunit
         public void SetUp()
         {
             this.RunnerFactory = new StubBoostTestRunnerFactory(new[] { "test.listcontent.exe" });
-            this.DiscovererFactory = new BoostTestDiscovererFactory(this.RunnerFactory);
+            this.DiscovererFactory = new BoostTestDiscovererFactory(this.RunnerFactory, DummyBoostTestPackageServiceFactory.Default);
         }
 
         #endregion Test Setup/Teardown
@@ -40,13 +41,6 @@ namespace BoostTestAdapterNunit
 
         #endregion Test Data
 
-        internal enum ListContentUse
-        {
-            Use,
-            ForceUse,
-            Default = Use
-        }
-
         #region Tests
 
         /// <summary>
@@ -55,56 +49,23 @@ namespace BoostTestAdapterNunit
         /// Test aims:
         ///     - Ensure that the proper ITestDiscoverer type is provided for the requested source.
         /// </summary>
-        // Exe types
-        [TestCase("test.exe", ListContentUse.Use, null, Result = null)]
-        [TestCase("test.exe", ListContentUse.ForceUse, null, Result = typeof(ListContentDiscoverer))]
-        [TestCase("test.listcontent.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
-        [TestCase("test.listcontent.exe", ListContentUse.ForceUse, null, Result = typeof(ListContentDiscoverer))]
-        [TestCase("test.exe", ListContentUse.Use, ".dll", Result = null)]
-        [TestCase("test.exe", ListContentUse.ForceUse, ".dll", Result = typeof(ListContentDiscoverer))]
-        [TestCase("test.listcontent.exe", ListContentUse.Use, ".dll", Result = typeof(ListContentDiscoverer))]
-        [TestCase("test.listcontent.exe", ListContentUse.ForceUse, ".dll", Result = typeof(ListContentDiscoverer))]
-        [TestCase("test.exe", ListContentUse.Use, ".exe", Result = typeof(ExternalDiscoverer))]
-        [TestCase("test.exe", ListContentUse.ForceUse, ".exe", Result = typeof(ExternalDiscoverer))]
-        [TestCase("test.listcontent.exe", ListContentUse.Use, ".exe", Result = typeof(ExternalDiscoverer))]
-        [TestCase("test.listcontent.exe", ListContentUse.ForceUse, ".exe", Result = typeof(ExternalDiscoverer))]
-        // .test.boostd.exe
-        [TestCase("test.test.boostd.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
-        [TestCase("test.test.boostd.exe", ListContentUse.ForceUse, null, Result = typeof(ListContentDiscoverer))]
-        // .test.boostd.exe (case-insensitive)
-        [TestCase("test.TEST.BOOSTD.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
-        // .test.boost.exe
-        [TestCase("test.test.boost.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
-        [TestCase("test.test.boost.exe", ListContentUse.ForceUse, null, Result = typeof(ListContentDiscoverer))]
-        // .test.boostd.exe (case-insensitive)
-        [TestCase("test.TEST.BOOST.EXE", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
-        // .AcceptanceTest.boostd.exe
-        [TestCase("test.AcceptanceTest.boostd.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
-        [TestCase("test.AcceptanceTest.boostd.exe", ListContentUse.ForceUse, null, Result = typeof(ListContentDiscoverer))]
-        // .Acceptancetest.boostd.exe (case-insensitive)
-        [TestCase("test.Acceptancetest.boostd.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
-        // .AcceptanceTest.boost.exe
-        [TestCase("test.AcceptanceTest.boost.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
-        [TestCase("test.AcceptanceTest.boost.exe", ListContentUse.ForceUse, null, Result = typeof(ListContentDiscoverer))]
-        // .Acceptancetest.boost.exe (case-insensitive)
-        [TestCase("test.Acceptancetest.boost.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
+        // Exe types - No '--list_content' support
+        [TestCase("test.exe", null, Result = null)]
+        [TestCase("test.exe", ".dll", Result = null)]
+        [TestCase("test.exe", ".exe", Result = typeof(ExternalDiscoverer))]
+        // Exe types - '--list_content' support
+        [TestCase("test.listcontent.exe", null, Result = typeof(ListContentDiscoverer))]
+        [TestCase("test.listcontent.exe", ".dll", Result = typeof(ListContentDiscoverer))]
+        [TestCase("test.listcontent.exe", ".exe", Result = typeof(ExternalDiscoverer))]
         // Dll types
-        [TestCase("test.dll", ListContentUse.Use, null, Result = null)]
-        [TestCase("test.dll", ListContentUse.Use, ".dll", Result = typeof(ExternalDiscoverer))]
-        [TestCase("test.dll", ListContentUse.Use, ".exe", Result = null)]
-        [TestCase("test.dll", ListContentUse.ForceUse, null, Result = null)]
-        [TestCase("test.dll", ListContentUse.ForceUse, ".dll", Result = typeof(ExternalDiscoverer))]
-        [TestCase("test.dll", ListContentUse.ForceUse, ".exe", Result = null)]
+        [TestCase("test.dll", null, Result = null)]
+        [TestCase("test.dll", ".dll", Result = typeof(ExternalDiscoverer))]
+        [TestCase("test.dll", ".exe", Result = null)]
         // Invalid extension types
-        [TestCase("test.txt", ListContentUse.Use, null, Result = null)]
-        [TestCase("test.txt", ListContentUse.Use, ".dll", Result = null)]
-        [TestCase("test.txt", ListContentUse.Use, ".exe", Result = null)]
-        [TestCase("test.txt", ListContentUse.ForceUse, null, Result = null)]
-        [TestCase("test.txt", ListContentUse.ForceUse, ".dll", Result = null)]
-        [TestCase("test.txt", ListContentUse.ForceUse, ".exe", Result = null)]
-        [TestCase("test.test.Acceptance.boostd.exe", ListContentUse.Use, null, Result = null)]
-        [TestCase("test.test.Acceptance.boost.exe", ListContentUse.Use, null, Result = null)]
-        public Type TestDiscovererProvisioning(string source, ListContentUse listContent, string externalExtension)
+        [TestCase("test.txt", null, Result = null)]
+        [TestCase("test.txt", ".dll", Result = null)]
+        [TestCase("test.txt", ".exe", Result = null)]
+        public Type TestDiscovererProvisioning(string source, string externalExtension)
         {
             ExternalBoostTestRunnerSettings externalSettings = null;
             
@@ -115,8 +76,7 @@ namespace BoostTestAdapterNunit
 
             BoostTestAdapterSettings settings = new BoostTestAdapterSettings()
             {
-                ExternalTestRunner = externalSettings,
-                ForceListContent = (listContent == ListContentUse.ForceUse)
+                ExternalTestRunner = externalSettings
             };
 
             IBoostTestDiscoverer discoverer = this.DiscovererFactory.GetDiscoverer(source, settings);

--- a/BoostTestAdapterNunit/Fakes/StubBoostTestRunnerFactory.cs
+++ b/BoostTestAdapterNunit/Fakes/StubBoostTestRunnerFactory.cs
@@ -45,8 +45,19 @@ namespace BoostTestAdapterNunit.Fakes
         {
             IBoostTestRunner runner = A.Fake<IBoostTestRunner>();
 
+            var capabilties = new BoostTestRunnerCapabilities
+            {
+                ListContent = ListContentSupport.Contains(identifier)
+            };
+
+            if (options.ForcedBoostTestVersion != null)
+            {
+                capabilties.ListContent = (options.ForcedBoostTestVersion >= DefaultBoostTestRunnerFactory.Boost159);
+                capabilties.Version = (options.ForcedBoostTestVersion >= DefaultBoostTestRunnerFactory.Boost163);
+            }
+            
             A.CallTo(() => runner.Source).Returns(identifier);
-            A.CallTo(() => runner.ListContentSupported).Returns(ListContentSupport.Contains(identifier));
+            A.CallTo(() => runner.Capabilities).Returns(capabilties);
 
             return runner;
         }

--- a/BoostTestAdapterNunit/ListContentDiscovererTest.cs
+++ b/BoostTestAdapterNunit/ListContentDiscovererTest.cs
@@ -80,6 +80,7 @@ namespace BoostTestAdapterNunit
             string output = null;
 
             A.CallTo(() => runner.ListContentSupported).Returns(true);
+            A.CallTo(() => runner.VersionSupported).Returns(false);
             A.CallTo(() => runner.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).Invokes((call) =>
             {
                 BoostTestRunnerCommandLineArgs args = (BoostTestRunnerCommandLineArgs) call.Arguments.First();
@@ -138,6 +139,7 @@ namespace BoostTestAdapterNunit
             IBoostTestRunner runner = A.Fake<IBoostTestRunner>();
                         
             A.CallTo(() => runner.ListContentSupported).Returns(true);
+            A.CallTo(() => runner.VersionSupported).Returns(false);
             A.CallTo(() => runner.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).Returns(-1073741515);
 
             FakeBoostTestRunnerFactory factory = new FakeBoostTestRunnerFactory(runner);
@@ -150,6 +152,95 @@ namespace BoostTestAdapterNunit
             
             // Ensure proper test discovery
             Assert.That(sink.Tests.Count, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Assert that: Given a Boost.Test module which supports --version, all discovered tests are annotated accordingly
+        /// </summary>
+        [Test]
+        public void VersionAnnotation()
+        {
+            IBoostTestRunner runner = A.Fake<IBoostTestRunner>();
+
+            A.CallTo(() => runner.ListContentSupported).Returns(true);
+            A.CallTo(() => runner.VersionSupported).Returns(true);
+            A.CallTo(() => runner.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).Invokes((call) =>
+            {
+                BoostTestRunnerCommandLineArgs args = (BoostTestRunnerCommandLineArgs) call.Arguments.First();
+
+                // --list_content=DOT
+                if ((args.ListContent.HasValue) && (args.ListContent.Value == ListContentFormat.DOT) && (!string.IsNullOrEmpty(args.StandardErrorFile)))
+                {
+                    TestHelper.CopyEmbeddedResourceToDirectory("BoostTestAdapterNunit.Resources.ListContentDOT.sample.3.list.content.gv", args.StandardErrorFile);
+                }
+                // --version
+                else if ((args.Version) && (!string.IsNullOrEmpty(args.StandardErrorFile)))
+                {
+                    TestHelper.CopyEmbeddedResourceToDirectory("BoostTestAdapterNunit.Resources.Version.sample.version.stderr.log", args.StandardErrorFile);
+                }
+            }).Returns(0);
+
+            FakeBoostTestRunnerFactory factory = new FakeBoostTestRunnerFactory(runner);
+            ListContentDiscoverer discoverer = new ListContentDiscoverer(factory, DummyBoostTestPackageServiceFactory.Default);
+
+            DefaultTestContext context = new DefaultTestContext();
+            DefaultTestCaseDiscoverySink sink = new DefaultTestCaseDiscoverySink();
+
+            discoverer.DiscoverTests(new[] { "test.exe", }, context, sink);
+
+            // Ensure proper test discovery
+            Assert.That(sink.Tests.Count, Is.Not.EqualTo(0));
+
+            // Ensure that version property is available
+            foreach (var test in sink.Tests)
+            {
+                var version = test.GetPropertyValue(VSTestModel.VersionProperty);
+                Assert.That(version, Is.EqualTo("1.63.0"));
+            }
+        }
+
+        /// <summary>
+        /// Assert that: Given a Boost.Test module which does not support --version, all discovered tests do not advertise the Boost version
+        /// </summary>
+        [Test]
+        public void NoVersionCapabilities()
+        {
+            IBoostTestRunner runner = A.Fake<IBoostTestRunner>();
+
+            A.CallTo(() => runner.ListContentSupported).Returns(true);
+            A.CallTo(() => runner.VersionSupported).Returns(false);
+            A.CallTo(() => runner.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).Invokes((call) =>
+            {
+                BoostTestRunnerCommandLineArgs args = (BoostTestRunnerCommandLineArgs)call.Arguments.First();
+
+                // --list_content=DOT
+                if ((args.ListContent.HasValue) && (args.ListContent.Value == ListContentFormat.DOT) && (!string.IsNullOrEmpty(args.StandardErrorFile)))
+                {
+                    TestHelper.CopyEmbeddedResourceToDirectory("BoostTestAdapterNunit.Resources.ListContentDOT.sample.3.list.content.gv", args.StandardErrorFile);
+                }
+                // --version
+                else if ((args.Version) && (!string.IsNullOrEmpty(args.StandardErrorFile)))
+                {
+                    TestHelper.CopyEmbeddedResourceToDirectory("BoostTestAdapterNunit.Resources.Version.missing.version.stderr.log", args.StandardErrorFile);
+                }
+            }).Returns(0);
+
+            FakeBoostTestRunnerFactory factory = new FakeBoostTestRunnerFactory(runner);
+            ListContentDiscoverer discoverer = new ListContentDiscoverer(factory, DummyBoostTestPackageServiceFactory.Default);
+
+            DefaultTestContext context = new DefaultTestContext();
+            DefaultTestCaseDiscoverySink sink = new DefaultTestCaseDiscoverySink();
+
+            discoverer.DiscoverTests(new[] { "test.exe", }, context, sink);
+
+            // Ensure proper test discovery
+            Assert.That(sink.Tests.Count, Is.Not.EqualTo(0));
+
+            // Ensure that version property is not available
+            foreach (var test in sink.Tests)
+            {
+                Assert.That(test.GetPropertyValue(VSTestModel.VersionProperty), Is.Null);
+            }
         }
     }
 }

--- a/BoostTestAdapterNunit/ListContentDiscovererTest.cs
+++ b/BoostTestAdapterNunit/ListContentDiscovererTest.cs
@@ -65,7 +65,7 @@ namespace BoostTestAdapterNunit
         }
 
         #endregion Helper Methods
-        
+
         /// <summary>
         /// List content discovery
         /// 
@@ -79,8 +79,7 @@ namespace BoostTestAdapterNunit
 
             string output = null;
 
-            A.CallTo(() => runner.ListContentSupported).Returns(true);
-            A.CallTo(() => runner.VersionSupported).Returns(false);
+            A.CallTo(() => runner.Capabilities).Returns(new BoostTestRunnerCapabilities { ListContent = true, Version = false });
             A.CallTo(() => runner.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).Invokes((call) =>
             {
                 BoostTestRunnerCommandLineArgs args = (BoostTestRunnerCommandLineArgs) call.Arguments.First();
@@ -137,9 +136,8 @@ namespace BoostTestAdapterNunit
         public void FailingExitCode()
         {
             IBoostTestRunner runner = A.Fake<IBoostTestRunner>();
-                        
-            A.CallTo(() => runner.ListContentSupported).Returns(true);
-            A.CallTo(() => runner.VersionSupported).Returns(false);
+
+            A.CallTo(() => runner.Capabilities).Returns(new BoostTestRunnerCapabilities { ListContent = true, Version = false });
             A.CallTo(() => runner.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).Returns(-1073741515);
 
             FakeBoostTestRunnerFactory factory = new FakeBoostTestRunnerFactory(runner);
@@ -162,8 +160,7 @@ namespace BoostTestAdapterNunit
         {
             IBoostTestRunner runner = A.Fake<IBoostTestRunner>();
 
-            A.CallTo(() => runner.ListContentSupported).Returns(true);
-            A.CallTo(() => runner.VersionSupported).Returns(true);
+            A.CallTo(() => runner.Capabilities).Returns(new BoostTestRunnerCapabilities { ListContent = true, Version = true });
             A.CallTo(() => runner.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).Invokes((call) =>
             {
                 BoostTestRunnerCommandLineArgs args = (BoostTestRunnerCommandLineArgs) call.Arguments.First();
@@ -207,8 +204,7 @@ namespace BoostTestAdapterNunit
         {
             IBoostTestRunner runner = A.Fake<IBoostTestRunner>();
 
-            A.CallTo(() => runner.ListContentSupported).Returns(true);
-            A.CallTo(() => runner.VersionSupported).Returns(false);
+            A.CallTo(() => runner.Capabilities).Returns(new BoostTestRunnerCapabilities { ListContent = true, Version = false });
             A.CallTo(() => runner.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).Invokes((call) =>
             {
                 BoostTestRunnerCommandLineArgs args = (BoostTestRunnerCommandLineArgs)call.Arguments.First();

--- a/BoostTestAdapterNunit/Resources/Version/missing.version.stderr.log
+++ b/BoostTestAdapterNunit/Resources/Version/missing.version.stderr.log
@@ -1,0 +1,8 @@
+An unrecognized parameter in the argument version
+
+Usage: test.exe [Boost.Test argument]... -- [custom test module argument]...
+
+For detailed help on Boost.Test parameters use:
+  test.exe --help
+or
+  test.exe --help=<parameter name>

--- a/BoostTestAdapterNunit/Resources/Version/sample.version.stderr.log
+++ b/BoostTestAdapterNunit/Resources/Version/sample.version.stderr.log
@@ -1,0 +1,5 @@
+Boost.Test module in executable 'test.exe'
+Compiled from Boost version 1.63.0 with static linking to Boost.Test
+- Compiler: Microsoft Visual C++ version 14.0
+- Platform: Win32
+- STL     : Dinkumware standard library version 650


### PR DESCRIPTION
Cherry-pick of etas/vs-boost-unit-test-adapter@dd2756ae27eacc248700952b883977a49b01d6f2.

This change was originally requested to avoid the use of debug symbols, possibly allowing for use of the test adapter in scenarios where the debug symbols are not emitted as part of the build process.

This change replaces the use of debug symbols (apart from testing for dynamic use Boost.Test). It is worth discussing if this is the preferred approach or if Boyer Moore search should merely act as a substitute to debug symbols should these symbols are not made available.

_P.S_ This PR should bring to a close the feature-parity attempt with the ETAS fork