### PR TITLE
Revert version change, version is set by build script

### DIFF
--- a/Antlr.DOT/Properties/AssemblyInfo.cs
+++ b/Antlr.DOT/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/BoostTestAdapter/Properties/AssemblyInfo.cs
+++ b/BoostTestAdapter/Properties/AssemblyInfo.cs
@@ -39,8 +39,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
 [assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
 
 #if !REALSIGN

--- a/BoostTestPackage/Properties/AssemblyInfo.cs
+++ b/BoostTestPackage/Properties/AssemblyInfo.cs
@@ -38,5 +38,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/BoostTestPlugin/Properties/AssemblyInfo.cs
+++ b/BoostTestPlugin/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/BoostTestPlugin/source.extension.vsixmanifest
+++ b/BoostTestPlugin/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="BoostUnitTestAdapter.95183667-1f65-419b-9cac-c9fbbed28f8b" Version="1.1.0.0" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="BoostUnitTestAdapter.95183667-1f65-419b-9cac-c9fbbed28f8b" Version="0.0.0.0" Language="en-US" Publisher="Microsoft" />
         <DisplayName>Test Adapter for Boost.Test</DisplayName>
         <Description xml:space="preserve">Enables Visual Studio's testing tools with unit tests written for Boost.Test.</Description>
         <PackageId>Microsoft.VisualStudio.VC.Ide.TestAdapterForBoostTest</PackageId>

--- a/BoostTestShared/Properties/AssemblyInfo.cs
+++ b/BoostTestShared/Properties/AssemblyInfo.cs
@@ -37,6 +37,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
 

--- a/VisualStudioAdapter/Properties/AssemblyInfo.cs
+++ b/VisualStudioAdapter/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]


### PR DESCRIPTION
Last update didn't stick since the version updater in the build script relies on the versions being set to 0.0.0.0