### PR TITLE
Dont include System.Memory.dll in vsix 

### DIFF
--- a/BoostTestPlugin/BoostTestPlugin.csproj
+++ b/BoostTestPlugin/BoostTestPlugin.csproj
@@ -226,6 +226,7 @@
     <SuppressFromVsix Include="MessagePack.Annotations.dll" />
     <SuppressFromVsix Include="MessagePack.dll" />
     <SuppressFromVsix Include="Microsoft.VisualStudio.Interop.dll" />
+    <SuppressFromVsix Include="System.Memory.dll" />
   </ItemGroup>
   <Target Name="SignThirdPartyFiles" BeforeTargets="GetVsixSourceItems" Condition="'$(RealSign)' == 'True'">
     <SignFiles Files="@(PublishThirdPartyFilesToSign)" Type="$(SignType)" BinariesDirectory="$(OutDir)" IntermediatesDirectory="$(IntermediateOutputPath)" Condition=" '@(PublishThirdPartyFilesToSign)' != '' " />


### PR DESCRIPTION
This dll can mess with other test adapters looking to use the same library. Instead we can defer to the one shipped in VS.