### PR TITLE
Add build+compliance pipeline with conversion to latest 1ES standards

### DIFF
--- a/TestAdapterforBoost.TestDev17.yml
+++ b/TestAdapterforBoost.TestDev17.yml
@@ -1,0 +1,216 @@
+# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
+# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
+# The SBOM tasks have been removed because they are not required for the unofficial template.
+# You can manually enable SBOM in the unofficial template if needed, othewise its automatically enabled when using official template. https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sbom
+# This pipeline will be extended to the OneESPT template
+# If you are not using the E+D shared hosted pool with windows-2022, replace the pool section with your hosted pool, os, and image name. If you are using a Linux image, you must specify an additional windows image for SDL: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/overview#how-to-specify-a-windows-pool-for-the-sdl-source-analysis-stage
+# The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish Artifact: drop' in the templateContext section.
+trigger:
+  branches:
+    include:
+    - refs/heads/dev17
+  batch: True
+name: $(date:yyyyMMdd)$(rev:.r)
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+variables:
+- name: ArtifactServices.Symbol.AccountName
+  value: devdiv
+- name: ArtifactServices.Symbol.PAT
+  value: "$(BoostTestSymbolsPat)"
+- name: ArtifactServices.Symbol.UseAAD
+  value: false
+- name: BuildConfiguration
+  value: Release
+- name: BuildPlatform
+  value: Any CPU
+- name: DropRoot
+  value: '\\cpvsbuild\drops'
+- name: Packaging.EnableSBOMSigning
+  value: False
+- name: ProductComponent
+  value: True
+- name: Publish
+  value: False
+- name: RealSign
+  value: False
+- name: RetainBuild
+  value: False
+- name: SignType
+  value: Test
+- name: TeamName
+  value: VCLS
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    pool:
+      name: VSEngSS-MicroBuild2022GPT-1ES
+    sdl:
+      sourceAnalysisPool:
+        name: VSEngSS-MicroBuild2022-1ES
+      sourceRepositoriesToScan:
+        exclude:
+        - repository: MicroBuildTemplate
+        - repository: vs-boost-unit-test-adapter
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: stage
+      jobs:
+      - job: Phase_1
+        displayName: Phase 1
+        timeoutInMinutes: 120
+        cancelTimeoutInMinutes: 1
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: drop'
+            targetPath: $(Build.ArtifactStagingDirectory)\drop
+        steps:
+        - checkout: self
+          displayName: 'Checkout vs-boost-unit-test-adapter Git Repo'
+          clean: true
+          fetchDepth: 1
+          persistCredentials: true
+        - task: NuGetToolInstaller@1
+          displayName: Install NuGet
+          inputs:
+            versionSpec: 5.9.1
+        - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
+          displayName: Install Localization Plugin
+        - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+          displayName: Install Signing Plugin
+          inputs:
+            signType: $(SignType)
+        - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@4
+          displayName: Install Swix Plugin
+        - task: PowerShell@2
+          displayName: Set Version
+          inputs:
+            targetType: filePath
+            filePath: './SetVersion.ps1'
+            arguments: '-version 1.1.0.10'
+        - task: PowerShell@1
+          displayName: Copy internal key
+          inputs:
+            scriptType: inlineScript
+            inlineScript: Invoke-WebRequest -Headers @{"AUTHORIZATION"="bearer $env:SYSTEM_ACCESSTOKEN"}-OutFile 'FinalPublicKey.snk' 'https://devdiv.visualstudio.com/DefaultCollection/0bdbc590-a062-4c3f-b0f6-9383f67865ee/0c9127d6-f650-4a04-9399-25be18b8e2fb/_api/_versioncontrol/itemContent?repositoryId=2961dea4-f77c-4c8e-b46f-72b6bfe62c29&path=%2FInternalAPIs%2FDevDiv%2FFinalPublicKey.snk&version=GBdev15'
+        - task: PowerShell@1
+          displayName: Add Keys for RealSign to TAfBT
+          inputs:
+            scriptType: inlineScript
+            inlineScript: |-
+              $projects_to_sign = @(
+                "Antlr.DOT\Antlr.DOT.csproj",
+                "BoostTestAdapter\BoostTestAdapter.csproj",
+                "BoostTestPackage\BoostTestPackage.csproj",
+                "BoostTestPlugin\BoostTestPlugin.csproj",
+                "BoostTestShared\BoostTestShared.csproj",
+                "ThirdPartySigning\ThirdPartySigning.csproj",
+                "VisualStudioAdapter\VisualStudioAdapter.csproj"
+              )
+              $projects_to_sign | ForEach-Object {
+                $xml = [xml](Get-Content $_)
+                $KeyFile = $xml.CreateElement("AssemblyOriginatorKeyFile", "http://schemas.microsoft.com/developer/msbuild/2003")
+                $KeyFile.set_InnerXML("`$(EnlistmentRoot)FinalPublicKey.snk")
+                $xml | ForEach-Object { $_.Project.PropertyGroup | ForEach-Object { if ($_.Condition -like '*(RealSign)'' == ''True''') { $_.AppendChild($KeyFile) } } }
+                $xml.Save("$pwd\$_")
+              }
+        - task: NuGetCommand@2
+          displayName: NuGet restore for ThirdPartySigning and MicroBuild.Core
+          inputs:
+            solution: packages.config
+            selectOrConfig: config
+            nugetConfigPath: NuGet.config
+            noCache: true
+            packagesDirectory: NuGetPackages
+        - task: NuGetCommand@2
+          displayName: NuGet restore
+          inputs:
+            solution: BoostTestAdapter.sln
+            selectOrConfig: config
+            nugetConfigPath: NuGet.config
+            noCache: true
+        - task: VSBuild@1
+          displayName: Build solution BoostTestAdapter.sln
+          inputs:
+            solution: BoostTestAdapter.sln
+            platform: $(BuildPlatform)
+            configuration: $(BuildConfiguration)
+            maximumCpuCount: true
+        - task: CopyFiles@2
+          displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)\drop'
+          inputs:
+            Contents: '**\out\binaries\**'
+            TargetFolder: $(Build.ArtifactStagingDirectory)\drop
+        - task: NuGetCommand@2
+          displayName: NuGet restore for vsmanproj
+          inputs:
+            solution: swix/packages.config
+            selectOrConfig: config
+            nugetConfigPath: NuGet.config
+            noCache: true
+            packagesDirectory: ..\NugetPackages
+          continueOnError: true
+        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+          displayName: 'Manifest Generator '
+          inputs:
+            BuildDropPath: '$(Build.ArtifactStagingDirectory)\drop'
+            PackageName: 'Test Adapter for Boost.Test'
+            PackageVersion: 1.1.0.4
+        - task: VSBuild@1
+          displayName: Build vsmanproj
+          condition: and(succeeded(), eq(variables['ProductComponent'], true))
+          inputs:
+            solution: swix/Microsoft.VisualStudio.VC.Ide.TestAdapterForBoostTest.vsmanproj
+            msbuildArgs: /p:ArtifactsDir=$(Build.ArtifactStagingDirectory)
+            platform: $(BuildPlatform)
+            configuration: $(BuildConfiguration)
+        - task: PublishSymbols@1
+          displayName: 'Publish symbols path: '
+          inputs:
+            SearchPattern: out\binaries\**\*.pdb
+          continueOnError: true
+        - task: CopyFiles@2
+          displayName: Copy setup files to drop root
+          inputs:
+            SourceFolder: out\binaries\$(BuildConfiguration)\Microsoft.VisualStudio.VC.Ide.TestAdapterForBoostTest
+            Contents: '*'
+            TargetFolder: $(Build.ArtifactStagingDirectory)\drop
+          continueOnError: true
+        - task: CopyFiles@2
+          displayName: Copy vsix to root
+          inputs:
+            SourceFolder: out\binaries\$(BuildConfiguration)\BoostTestPlugin
+            Contents: BoostUnitTestAdapter.vsix
+            TargetFolder: $(Build.ArtifactStagingDirectory)\drop
+          continueOnError: true
+        - task: 1ES.MicroBuildVstsDrop@1
+          displayName: Upload VSTS Drop
+          inputs:
+            dropFolder: $(Build.ArtifactStagingDirectory)\drop
+            dropName: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
+            accessToken: $(System.AccessToken)
+            dropServiceUri: https://devdiv.artifacts.visualstudio.com/DefaultCollection
+            vsDropServiceUri: "https://vsdrop.corp.microsoft.com/file/v1"
+        - task: ms-vseng.MicroBuildShipTasks.4a4e1dc3-01d0-484f-94ac-f918aaf7d509.MicroBuildRetainVstsDrops@1
+          displayName: Retain VSTS Drops
+          condition: and(succeeded(), eq(variables['RetainBuild'], true))
+          inputs:
+            DropNames: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
+            AccessToken: $(System.AccessToken)
+            DropServiceUri: https://devdiv.artifacts.visualstudio.com/DefaultCollection
+        - task: PublishSymbols@2
+          displayName: Publish symbols path
+          inputs:
+            SymbolsFolder: $(Build.ArtifactStagingDirectory)\drop
+            SearchPattern: '**/*.pdb'
+            SymbolServerType: TeamServices
+            TreatNotIndexedAsWarning: true
+        - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+          displayName: Perform Cleanup Tasks
+          condition: always()

--- a/TestAdapterforBoost.TestDev17.yml
+++ b/TestAdapterforBoost.TestDev17.yml
@@ -5,11 +5,7 @@
 # This pipeline will be extended to the OneESPT template
 # If you are not using the E+D shared hosted pool with windows-2022, replace the pool section with your hosted pool, os, and image name. If you are using a Linux image, you must specify an additional windows image for SDL: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/overview#how-to-specify-a-windows-pool-for-the-sdl-source-analysis-stage
 # The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish Artifact: drop' in the templateContext section.
-trigger:
-  branches:
-    include:
-    - refs/heads/dev17
-  batch: True
+trigger: none
 schedules:
   - cron: "0 7 1 * *"
     displayName: Monthly Run
@@ -17,7 +13,6 @@ schedules:
       include:
         - refs/heads/dev17
     always: true
-name: $(date:yyyyMMdd)$(rev:.r)
 resources:
   repositories:
   - repository: MicroBuildTemplate
@@ -112,9 +107,7 @@ extends:
           inputs:
             targetType: filePath
             filePath: './SetVersion.ps1'
-            arguments: '-version $(PassVariable.VersionNumber)'
-          env:
-            VersionNumber: $(VersionNumber)
+            arguments: '-version $(VersionNumber)'
         - task: PowerShell@1
           displayName: Copy internal key
           inputs:

--- a/TestAdapterforBoost.TestDev17.yml
+++ b/TestAdapterforBoost.TestDev17.yml
@@ -18,6 +18,12 @@ resources:
     name: 1ESPipelineTemplates/MicroBuildTemplate
     ref: refs/tags/release
 variables:
+- name: ApiScanClientId
+  value: 1d6a3de7-4a6a-4b75-b15d-e305293c75af
+- name: ApiScanSecret
+  value: "$(TAfBTAPIScanSecret)"
+- name: ApiScanTenant
+  value: 72f988bf-86f1-41af-91ab-2d7cd011db47
 - name: ArtifactServices.Symbol.AccountName
   value: devdiv
 - name: ArtifactServices.Symbol.PAT
@@ -25,23 +31,27 @@ variables:
 - name: ArtifactServices.Symbol.UseAAD
   value: false
 - name: BuildConfiguration
-  value: Release
+  value: "$(TAfBTBuildConfiguration)"
 - name: BuildPlatform
   value: Any CPU
+- name: CodeQL.Enabled
+  value: True
+- name: CodeQL.TSAEnabled
+  value: True
 - name: DropRoot
   value: '\\cpvsbuild\drops'
 - name: Packaging.EnableSBOMSigning
-  value: False
+  value: "$(TAfBTEnableSBOMSigning)"
 - name: ProductComponent
-  value: True
+  value: "$(TAfBTProductComponent)"
 - name: Publish
-  value: False
+  value: "$(TAfBTPublish)"
 - name: RealSign
-  value: False
+  value: "$(TAfBTRealSign)"
 - name: RetainBuild
-  value: False
+  value: "$(TAfBTRetainBuild)"
 - name: SignType
-  value: Test
+  value: "$(TAfBTSignType)"
 - name: TeamName
   value: VCLS
 extends:
@@ -63,13 +73,13 @@ extends:
       jobs:
       - job: Phase_1
         displayName: Phase 1
-        timeoutInMinutes: 120
+        timeoutInMinutes: 0
         cancelTimeoutInMinutes: 1
         templateContext:
           outputs:
           - output: pipelineArtifact
-            displayName: 'Publish Artifact: drop'
-            targetPath: $(Build.ArtifactStagingDirectory)\drop
+            displayName: 'Publish Artifact: templateContextDrop'
+            targetPath: $(Build.ArtifactStagingDirectory)\templateContextDrop
         steps:
         - checkout: self
           displayName: 'Checkout vs-boost-unit-test-adapter Git Repo'
@@ -143,10 +153,16 @@ extends:
             configuration: $(BuildConfiguration)
             maximumCpuCount: true
         - task: CopyFiles@2
-          displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)\drop'
+          displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)\BoostTestDrop'
           inputs:
             Contents: '**\out\binaries\**'
-            TargetFolder: $(Build.ArtifactStagingDirectory)\drop
+            TargetFolder: $(Build.ArtifactStagingDirectory)\BoostTestDrop
+        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+          displayName: 'Manifest Generator '
+          inputs:
+            BuildDropPath: '$(Build.ArtifactStagingDirectory)\BoostTestDrop'
+            PackageName: 'Test Adapter for Boost.Test'
+            PackageVersion: 1.1.0.4
         - task: NuGetCommand@2
           displayName: NuGet restore for vsmanproj
           inputs:
@@ -156,12 +172,6 @@ extends:
             noCache: true
             packagesDirectory: ..\NugetPackages
           continueOnError: true
-        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-          displayName: 'Manifest Generator '
-          inputs:
-            BuildDropPath: '$(Build.ArtifactStagingDirectory)\drop'
-            PackageName: 'Test Adapter for Boost.Test'
-            PackageVersion: 1.1.0.4
         - task: VSBuild@1
           displayName: Build vsmanproj
           condition: and(succeeded(), eq(variables['ProductComponent'], true))
@@ -170,25 +180,41 @@ extends:
             msbuildArgs: /p:ArtifactsDir=$(Build.ArtifactStagingDirectory)
             platform: $(BuildPlatform)
             configuration: $(BuildConfiguration)
-        - task: PublishSymbols@1
-          displayName: 'Publish symbols path: '
-          inputs:
-            SearchPattern: out\binaries\**\*.pdb
-          continueOnError: true
         - task: CopyFiles@2
-          displayName: Copy setup files to drop root
+          displayName: Copy setup files to BoostTestDrop root
           inputs:
             SourceFolder: out\binaries\$(BuildConfiguration)\Microsoft.VisualStudio.VC.Ide.TestAdapterForBoostTest
             Contents: '*'
-            TargetFolder: $(Build.ArtifactStagingDirectory)\drop
+            TargetFolder: $(Build.ArtifactStagingDirectory)\BoostTestDrop
           continueOnError: true
         - task: CopyFiles@2
           displayName: Copy vsix to root
           inputs:
             SourceFolder: out\binaries\$(BuildConfiguration)\BoostTestPlugin
             Contents: BoostUnitTestAdapter.vsix
-            TargetFolder: $(Build.ArtifactStagingDirectory)\drop
+            TargetFolder: $(Build.ArtifactStagingDirectory)\BoostTestDrop
           continueOnError: true
+        - task: PoliCheck@2
+          inputs:
+            targetType: 'F'
+            targetArgument: '$(Build.SourcesDirectory)'
+        - task: 1ES.PublishPipelineArtifact@1
+          displayName: 'Publish Artifact: BoostTestDrop'
+          inputs:
+            path: '$(Build.ArtifactStagingDirectory)\BoostTestDrop'
+            artifact: BoostTestDrop
+        - task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@2
+          displayName: 'Run APIScan'
+          inputs:
+            softwareFolder: '$(Build.ArtifactStagingDirectory)\BoostTestDrop'
+            softwareName: BoostTest
+            softwareVersionNum: 1.0
+            isLargeApp: false
+            toolVersion: 'Latest'
+            verbosityLevel: silent
+            continueOnError: true
+          env:
+            AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
         - task: 1ES.MicroBuildVstsDrop@1
           displayName: Upload VSTS Drop
           inputs:
@@ -211,6 +237,17 @@ extends:
             SearchPattern: '**/*.pdb'
             SymbolServerType: TeamServices
             TreatNotIndexedAsWarning: true
+        - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
+          displayName: 'Publish Guardian Artifacts'
+          inputs:
+            PublishProcessedResults: true
+          continueOnError: true
+        - task: TSAUpload@2
+          displayName: 'TSA Upload'
+          inputs:
+            GdnPublishTsaOnboard: false
+            GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\TSAOptions.json'
+          continueOnError: true
         - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
           displayName: Perform Cleanup Tasks
           condition: always()

--- a/TestAdapterforBoost.TestDev17.yml
+++ b/TestAdapterforBoost.TestDev17.yml
@@ -10,6 +10,13 @@ trigger:
     include:
     - refs/heads/dev17
   batch: True
+schedules:
+  - cron: "0 7 1 * *"
+    displayName: Monthly Run
+    branches:
+      include:
+        - refs/heads/dev17
+    always: true
 name: $(date:yyyyMMdd)$(rev:.r)
 resources:
   repositories:
@@ -46,6 +53,9 @@ variables:
   value: "$(TAfBTProductComponent)"
 - name: Publish
   value: "$(TAfBTPublish)"
+# Quick build is used to skip some compliance tasks to quickly generate a .vsix for testing.
+- name: QuickBuild
+  value: "$(TAfBTQuickBuild)"
 - name: RealSign
   value: "$(TAfBTRealSign)"
 - name: RetainBuild
@@ -54,6 +64,8 @@ variables:
   value: "$(TAfBTSignType)"
 - name: TeamName
   value: VCLS
+- name: VersionNumber
+  value: "$(TAfBTVersionNumber)"
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
@@ -63,9 +75,6 @@ extends:
       sourceAnalysisPool:
         name: VSEngSS-MicroBuild2022-1ES
       sourceRepositoriesToScan:
-        exclude:
-        - repository: MicroBuildTemplate
-        - repository: vs-boost-unit-test-adapter
     customBuildTags:
     - ES365AIMigrationTooling
     stages:
@@ -78,8 +87,8 @@ extends:
         templateContext:
           outputs:
           - output: pipelineArtifact
-            displayName: 'Publish Artifact: templateContextDrop'
-            targetPath: $(Build.ArtifactStagingDirectory)\templateContextDrop
+            displayName: 'Publish Artifact: drop'
+            targetPath: $(Build.ArtifactStagingDirectory)\drop
         steps:
         - checkout: self
           displayName: 'Checkout vs-boost-unit-test-adapter Git Repo'
@@ -103,7 +112,9 @@ extends:
           inputs:
             targetType: filePath
             filePath: './SetVersion.ps1'
-            arguments: '-version 1.1.0.10'
+            arguments: '-version $(PassVariable.VersionNumber)'
+          env:
+            VersionNumber: $(VersionNumber)
         - task: PowerShell@1
           displayName: Copy internal key
           inputs:
@@ -194,17 +205,17 @@ extends:
             Contents: BoostUnitTestAdapter.vsix
             TargetFolder: $(Build.ArtifactStagingDirectory)\BoostTestDrop
           continueOnError: true
+        # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
         - task: PoliCheck@2
+          displayName: 'PoliCheck'
+          condition: eq (variables.QuickBuild, False)
           inputs:
             targetType: 'F'
             targetArgument: '$(Build.SourcesDirectory)'
-        - task: 1ES.PublishPipelineArtifact@1
-          displayName: 'Publish Artifact: BoostTestDrop'
-          inputs:
-            path: '$(Build.ArtifactStagingDirectory)\BoostTestDrop'
-            artifact: BoostTestDrop
+        # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
         - task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@2
           displayName: 'Run APIScan'
+          condition: eq (variables.QuickBuild, False)
           inputs:
             softwareFolder: '$(Build.ArtifactStagingDirectory)\BoostTestDrop'
             softwareName: BoostTest
@@ -215,6 +226,21 @@ extends:
             continueOnError: true
           env:
             AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
+        # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
+        - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
+          displayName: 'Publish Guardian Artifacts'
+          condition: eq (variables.QuickBuild, False)
+          inputs:
+            PublishProcessedResults: true
+          continueOnError: true
+        # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
+        - task: TSAUpload@2
+          displayName: 'TSA Upload'
+          condition: eq (variables.QuickBuild, False)
+          inputs:
+            GdnPublishTsaOnboard: false
+            GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\TSAOptions.json'
+          continueOnError: true
         - task: 1ES.MicroBuildVstsDrop@1
           displayName: Upload VSTS Drop
           inputs:
@@ -237,17 +263,11 @@ extends:
             SearchPattern: '**/*.pdb'
             SymbolServerType: TeamServices
             TreatNotIndexedAsWarning: true
-        - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
-          displayName: 'Publish Guardian Artifacts'
+        - task: 1ES.PublishPipelineArtifact@1
+          displayName: 'Publish Artifact: BoostTestDrop'
           inputs:
-            PublishProcessedResults: true
-          continueOnError: true
-        - task: TSAUpload@2
-          displayName: 'TSA Upload'
-          inputs:
-            GdnPublishTsaOnboard: false
-            GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\TSAOptions.json'
-          continueOnError: true
+            path: '$(Build.ArtifactStagingDirectory)\BoostTestDrop'
+            artifact: BoostTestDrop
         - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
           displayName: Perform Cleanup Tasks
           condition: always()

--- a/TestAdapterforBoost.TestDev17.yml
+++ b/TestAdapterforBoost.TestDev17.yml
@@ -157,14 +157,14 @@ extends:
             configuration: $(BuildConfiguration)
             maximumCpuCount: true
         - task: CopyFiles@2
-          displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)\BoostTestDrop'
+          displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)\drop'
           inputs:
             Contents: '**\out\binaries\**'
-            TargetFolder: $(Build.ArtifactStagingDirectory)\BoostTestDrop
+            TargetFolder: $(Build.ArtifactStagingDirectory)\drop
         - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
           displayName: 'Manifest Generator '
           inputs:
-            BuildDropPath: '$(Build.ArtifactStagingDirectory)\BoostTestDrop'
+            BuildDropPath: '$(Build.ArtifactStagingDirectory)\drop'
             PackageName: 'Test Adapter for Boost.Test'
             PackageVersion: 1.1.0.4
         - task: NuGetCommand@2
@@ -185,18 +185,18 @@ extends:
             platform: $(BuildPlatform)
             configuration: $(BuildConfiguration)
         - task: CopyFiles@2
-          displayName: Copy setup files to BoostTestDrop root
+          displayName: Copy setup files to drop root
           inputs:
             SourceFolder: out\binaries\$(BuildConfiguration)\Microsoft.VisualStudio.VC.Ide.TestAdapterForBoostTest
             Contents: '*'
-            TargetFolder: $(Build.ArtifactStagingDirectory)\BoostTestDrop
+            TargetFolder: $(Build.ArtifactStagingDirectory)\drop
           continueOnError: true
         - task: CopyFiles@2
           displayName: Copy vsix to root
           inputs:
             SourceFolder: out\binaries\$(BuildConfiguration)\BoostTestPlugin
             Contents: BoostUnitTestAdapter.vsix
-            TargetFolder: $(Build.ArtifactStagingDirectory)\BoostTestDrop
+            TargetFolder: $(Build.ArtifactStagingDirectory)\drop
           continueOnError: true
         # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
         - task: PoliCheck@2
@@ -210,7 +210,7 @@ extends:
           displayName: 'Run APIScan'
           condition: eq (variables.QuickBuild, False)
           inputs:
-            softwareFolder: '$(Build.ArtifactStagingDirectory)\BoostTestDrop'
+            softwareFolder: '$(Build.ArtifactStagingDirectory)\drop'
             softwareName: BoostTest
             softwareVersionNum: 1.0
             isLargeApp: false
@@ -256,11 +256,6 @@ extends:
             SearchPattern: '**/*.pdb'
             SymbolServerType: TeamServices
             TreatNotIndexedAsWarning: true
-        - task: 1ES.PublishPipelineArtifact@1
-          displayName: 'Publish Artifact: BoostTestDrop'
-          inputs:
-            path: '$(Build.ArtifactStagingDirectory)\BoostTestDrop'
-            artifact: BoostTestDrop
         - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
           displayName: Perform Cleanup Tasks
           condition: always()

--- a/swix/Microsoft.VisualStudio.VC.Ide.TestAdapterForBoostTest.vsmanproj
+++ b/swix/Microsoft.VisualStudio.VC.Ide.TestAdapterForBoostTest.vsmanproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <TargetFrameworkVersion Condition="'$(MSBuildProjectExtension)' == '.vsmanproj'">v4.7.2</TargetFrameworkVersion>
     <FinalizeManifest>true</FinalizeManifest>
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
 


### PR DESCRIPTION
Converted Boost Test Adapter ADO classic pipelines for build and compliance into one centralized build/compliance pipeline for dev17. This converted pipeline now uses the new 1ES template.

Since this new pipeline also runs time-consuming compliance tasks, the new QuickBuild variable (off by default) allows you to skip those compliance tasks to quickly build and generated a .vsix.

The new flow will be to enable quick build when quickly testing an experimental vsix. When publishing a new version of TAfBT turn all variables (except Quick Build) to True.

Old build pipeline: https://devdiv.visualstudio.com/DevDiv/_build?definitionId=7213
Old compliance pipeline: https://devdiv.visualstudio.com/DevDiv/_build?definitionId=13119