### PR TITLE
Update TSAOptions.json path to fix CodeQL reporting

### DIFF
--- a/TestAdapterforBoost.TestDev17.yml
+++ b/TestAdapterforBoost.TestDev17.yml
@@ -55,6 +55,8 @@ variables:
   value: True
 - name: CodeQL.TSAEnabled
   value: True
+- name: Codeql.TSAOptionsPath
+  value: $(Build.SourcesDirectory)\vs-boost-unit-test-adapter\TSAOptions.json
 - name: DropRoot
   value: '\\cpvsbuild\drops'
 - name: Packaging.EnableSBOMSigning


### PR DESCRIPTION
Update CodeQL variable to to know where to look for for TSAOptions.json. Since this pipeline checks out more than one repo it is not in the default location of Build.SourcesDirectory, but rather in Build.SourcesDirectory/TestAdapterForGoogleTest. Repo names have to be specified in paths when pipelines check out multiple repos.