### PR TITLE
Add PreFast scan to sdl source scanning

### DIFF
--- a/TestAdapterforBoost.TestDev17.yml
+++ b/TestAdapterforBoost.TestDev17.yml
@@ -197,6 +197,7 @@ extends:
             platform: $(BuildPlatform)
             configuration: $(BuildConfiguration)
             maximumCpuCount: true
+            createLogFile: true
         - task: CopyFiles@2
           displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)\drop'
           inputs:
@@ -245,6 +246,17 @@ extends:
           inputs:
             filePath: './FilesToScan.ps1'
             arguments: '-buildArtifactStagingDirectory $(Build.ArtifactStagingDirectory) -directoryToSearch $(Build.ArtifactStagingDirectory)\drop'
+        # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
+        - task: SDLNativeRules@3
+          displayName: 'Run the PREfast SDL Native Rules for MSBuild'
+          condition: eq (variables.RunAdditionalComplianceChecks, True)
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          inputs:
+            publishXML: true
+            userProvideBuildInfo: auto
+            rulesetName: Recommended
+            setupCommandlinePicker: 'vs2022'
         # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
         - task: PoliCheck@2
           displayName: 'PoliCheck on vs-boost-unit-test-adapter repo'


### PR DESCRIPTION
Since these pipelines checkout other repos, then when it scans the source it will scan everything rather than just the one repo we want.

For example, the TAfGT pipeline should only scan the TAfGT repo, but since we also checkout the googletest repo when building and the VCLS_Extensions when signing, then it also tries to scan all that source code. The scans for those repos should be done in their own individual pipelines that belong to those repos, or we'll get lots of duplicate bugs.

You can see we do the same for PoliCheck task where we use the manual task rather than the auto-injected one so that we can scan only the repo we want. 