### PR TITLE
Update Microsoft.VisualStudio.Shell.15.0 nuget package to latest version available

### DIFF
--- a/BoostTestPackage/BoostTestPackage.csproj
+++ b/BoostTestPackage/BoostTestPackage.csproj
@@ -94,8 +94,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.8.37221" />
-    <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.0.0-preview-2-31221-277" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.13.40008" />
+    <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.13.40008" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/VisualStudioAdapter/VisualStudioAdapter.csproj
+++ b/VisualStudioAdapter/VisualStudioAdapter.csproj
@@ -60,9 +60,9 @@
     <Compile Include="VSDebugConfiguration.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.8.37221" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.13.40008" />
     <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="17.0.5-preview-0001-g696a30d1cc" />
-    <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.0.0-preview-2-31221-277" />
+    <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.13.40008" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Previous package version was the latest version available in vc-test-adapters feed but not latest version publicly available. Latest version was added to vc-test-adapters so it can be injected in this test adapter.