### PR TITLE
Update archive symbols to not require PAT

### DIFF
--- a/TestAdapterforBoost.TestDev17.yml
+++ b/TestAdapterforBoost.TestDev17.yml
@@ -43,12 +43,6 @@ variables:
   value: d318cba7-db4d-4fb3-99e1-01879cb74e91
 - name: ArchiveSymbols
   value: "$(TAfBTArchiveSymbols)"
-- name: ArtifactServices.Symbol.AccountName
-  value: devdiv
-- name: ArtifactServices.Symbol.PAT
-  value: "$(BoostTestSymbolsPat)"
-- name: ArtifactServices.Symbol.UseAAD
-  value: false
 - name: BuildConfiguration
   value: "$(TAfBTBuildConfiguration)"
 - name: BuildPlatform
@@ -315,10 +309,13 @@ extends:
             DropNames: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
             AccessToken: $(System.AccessToken)
             DropServiceUri: https://devdiv.artifacts.visualstudio.com/DefaultCollection
-        - task: PublishSymbols@1
-          displayName: 'Publish Symbols Path'
+        - task: PublishSymbols@2
+          displayName: 'Enable Source Server'
           inputs:
-            SearchPattern: out\binaries\**\*.pdb
+            SearchPattern: 'out\binaries\**\*.pdb'
+            # We use the MicroBuild Archive Symbols task so we need to publish the symbols here.
+            # See the following for more info: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/34299/Handling-Symbols
+            PublishSymbols: false
           continueOnError: true
         - task: ms-vseng.MicroBuildShipTasks.0ffdda1d-8c7b-40da-b8b1-061660eaeea3.MicroBuildArchiveSymbols@5
           displayName: 'Archive TestAdapterForBoostTest on Symweb'


### PR DESCRIPTION
The MicroBuildArchiveSymbols task uses a managed identity so there is no need to use a PAT anymore. See these wikis for complete documentation.
https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/34299/Handling-Symbols
https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/34315/Archiving-Symbols