### PR TITLE
Fix archive symbols error and run pipelines on the main branch

### DIFF
--- a/pipeline/common.yml
+++ b/pipeline/common.yml
@@ -267,6 +267,8 @@ jobs:
       SymbolsFeatureName: TestAdapterForBoostTest
       SymbolsProject: VS
       SymbolsAgentPath: '$(Build.ArtifactStagingDirectory)\drop'
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
   - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
     displayName: 'Send Telemetry'
     condition: and(eq (variables.ArchiveSymbols, True), eq('${{ parameters.IsProd }}', true))

--- a/pipeline/nonprod.yml
+++ b/pipeline/nonprod.yml
@@ -2,6 +2,7 @@ pr:
   autoCancel: true
   branches:
     include:
+    - refs/heads/main
     - refs/heads/dev17
     - refs/heads/dev15
     - dev/*

--- a/pipeline/prod.yml
+++ b/pipeline/prod.yml
@@ -1,4 +1,5 @@
 trigger:
+- refs/heads/main
 - refs/heads/dev17
 - refs/heads/dev15
 schedules:
@@ -6,7 +7,7 @@ schedules:
     displayName: Monthly Run
     branches:
       include:
-        - refs/heads/dev17
+        - refs/heads/main
     always: true
 name: $(date:yyyyMMdd)$(rev:.r)
 resources:


### PR DESCRIPTION
Running pipelines on the main branch is to support the upcoming rename of the dev17 branch to main.